### PR TITLE
bashbrew: pass DOCKER_BUILD_COMMIT argument to docker build

### DIFF
--- a/cmd/bashbrew/cmd-build.go
+++ b/cmd/bashbrew/cmd-build.go
@@ -93,7 +93,7 @@ func cmdBuild(c *cli.Context) error {
 
 					// TODO use "meta.StageNames" to do "docker build --target" so we can tag intermediate stages too for cache (streaming "git archive" directly to "docker build" makes that a little hard to accomplish without re-streaming)
 
-					err = dockerBuild(cacheTag, entry.ArchFile(arch), archive)
+					err = dockerBuild(cacheTag, entry.ArchFile(arch), archive, commit)
 					if err != nil {
 						return cli.NewMultiError(fmt.Errorf(`failed building %q (tags %q)`, r.RepoName, entry.TagsString()), err)
 					}

--- a/cmd/bashbrew/docker.go
+++ b/cmd/bashbrew/docker.go
@@ -237,8 +237,9 @@ func (r Repo) dockerBuildUniqueBits(entry *manifest.Manifest2822Entry) ([]string
 	return uniqueBits, nil
 }
 
-func dockerBuild(tag string, file string, context io.Reader) error {
-	args := []string{"build", "-t", tag, "-f", file, "--rm", "--force-rm"}
+func dockerBuild(tag string, file string, context io.Reader, commit string) error {
+	args := []string{"build", "-t", tag, "-f", file, "--rm", "--force-rm", "--build-arg",
+		fmt.Sprintf("DOCKER_BUILD_COMMIT=%s", commit)}
 	args = append(args, "-")
 	cmd := exec.Command("docker", args...)
 	cmd.Stdin = context


### PR DESCRIPTION
This will allow to identify the image being built inside the Dockerfile and set things like binary version number accordingly.

If setting build arguments is not acceptable I could include the `.git` directory in the archive instead. Feedback/any other suggestions appreciated.