### PR TITLE
Merge github.com/docker-library/go-dockerlibrary into bashbrew

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,9 @@
 **
+!architecture/
 !bashbrew.sh
 !cmd/
 !go.mod
 !go.sum
+!manifest/
+!pkg/
 !scripts/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,14 @@ jobs:
           bin/bashbrew list --uniq "$image"
           bin/bashbrew cat "$image"
           bin/bashbrew from --uniq "$image"
+  go-test:
+    name: Go Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Go Test
+        run: |
+          docker build --pull --file Dockerfile.test .
   dockerfile:
     name: Test Dockerfile
     runs-on: ubuntu-latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,8 +14,7 @@ WORKDIR /usr/src/bashbrew
 COPY go.mod go.sum ./
 RUN go mod download; go mod verify
 
-COPY bashbrew.sh ./
-COPY cmd cmd
+COPY . .
 RUN export CGO_ENABLED=0; \
 	bash -x ./bashbrew.sh --version; \
 	rm -r ~/.cache/go-build; \

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,0 +1,14 @@
+FROM golang:1.13-buster
+
+SHELL ["bash", "-Eeuo", "pipefail", "-xc"]
+
+WORKDIR /usr/src/bashbrew
+
+COPY go.mod go.sum ./
+RUN go mod download; go mod verify
+
+COPY . .
+
+RUN go test -v -race -coverprofile=coverage.out ./...
+
+RUN go tool cover -func=coverage.out

--- a/architecture/oci-platform.go
+++ b/architecture/oci-platform.go
@@ -1,0 +1,26 @@
+package architecture
+
+// https://github.com/opencontainers/image-spec/blob/v1.0.1/image-index.md#image-index-property-descriptions
+// see "platform" (under "manifests")
+type OCIPlatform struct {
+	OS           string `json:"os"`
+	Architecture string `json:"architecture"`
+	Variant      string `json:"variant,omitempty"`
+
+	//OSVersion  string   `json:"os.version,omitempty"`
+	//OSFeatures []string `json:"os.features,omitempty"`
+}
+
+var SupportedArches = map[string]OCIPlatform{
+	"amd64":    {OS: "linux", Architecture: "amd64"},
+	"arm32v5":  {OS: "linux", Architecture: "arm", Variant: "v5"},
+	"arm32v6":  {OS: "linux", Architecture: "arm", Variant: "v6"},
+	"arm32v7":  {OS: "linux", Architecture: "arm", Variant: "v7"},
+	"arm64v8":  {OS: "linux", Architecture: "arm64", Variant: "v8"},
+	"i386":     {OS: "linux", Architecture: "386"},
+	"mips64le": {OS: "linux", Architecture: "mips64le"},
+	"ppc64le":  {OS: "linux", Architecture: "ppc64le"},
+	"s390x":    {OS: "linux", Architecture: "s390x"},
+
+	"windows-amd64": {OS: "windows", Architecture: "amd64"},
+}

--- a/cmd/bashbrew/cmd-cat.go
+++ b/cmd/bashbrew/cmd-cat.go
@@ -8,8 +8,8 @@ import (
 	"text/template"
 
 	"github.com/codegangsta/cli"
-	"github.com/docker-library/go-dockerlibrary/manifest"
-	"github.com/docker-library/go-dockerlibrary/pkg/templatelib"
+	"github.com/docker-library/bashbrew/manifest"
+	"github.com/docker-library/bashbrew/pkg/templatelib"
 )
 
 var DefaultCatFormat = `

--- a/cmd/bashbrew/cmd-deps.go
+++ b/cmd/bashbrew/cmd-deps.go
@@ -8,7 +8,7 @@ import (
 	"github.com/codegangsta/cli"
 	"pault.ag/go/topsort"
 
-	"github.com/docker-library/go-dockerlibrary/manifest"
+	"github.com/docker-library/bashbrew/manifest"
 )
 
 func cmdOffspring(c *cli.Context) error {

--- a/cmd/bashbrew/cmd-list.go
+++ b/cmd/bashbrew/cmd-list.go
@@ -5,7 +5,7 @@ import (
 	"path"
 
 	"github.com/codegangsta/cli"
-	"github.com/docker-library/go-dockerlibrary/manifest"
+	"github.com/docker-library/bashbrew/manifest"
 )
 
 func cmdList(c *cli.Context) error {

--- a/cmd/bashbrew/cmd-put-shared.go
+++ b/cmd/bashbrew/cmd-put-shared.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/codegangsta/cli"
 
-	"github.com/docker-library/go-dockerlibrary/architecture"
-	"github.com/docker-library/go-dockerlibrary/manifest"
+	"github.com/docker-library/bashbrew/architecture"
+	"github.com/docker-library/bashbrew/manifest"
 )
 
 func entriesToManifestToolYaml(singleArch bool, r Repo, entries ...*manifest.Manifest2822Entry) (string, time.Time, int, error) {

--- a/cmd/bashbrew/config.go
+++ b/cmd/bashbrew/config.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 
 	"github.com/codegangsta/cli"
-	"github.com/docker-library/go-dockerlibrary/pkg/stripper"
+	"github.com/docker-library/bashbrew/pkg/stripper"
 	"pault.ag/go/debian/control"
 )
 

--- a/cmd/bashbrew/docker.go
+++ b/cmd/bashbrew/docker.go
@@ -14,7 +14,7 @@ import (
 	"strings"
 
 	"github.com/codegangsta/cli"
-	"github.com/docker-library/go-dockerlibrary/manifest"
+	"github.com/docker-library/bashbrew/manifest"
 )
 
 type dockerfileMetadata struct {

--- a/cmd/bashbrew/git.go
+++ b/cmd/bashbrew/git.go
@@ -13,8 +13,8 @@ import (
 
 	"github.com/codegangsta/cli"
 
-	"github.com/docker-library/go-dockerlibrary/manifest"
-	"github.com/docker-library/go-dockerlibrary/pkg/execpipe"
+	"github.com/docker-library/bashbrew/manifest"
+	"github.com/docker-library/bashbrew/pkg/execpipe"
 
 	goGit "github.com/go-git/go-git/v5"
 	goGitConfig "github.com/go-git/go-git/v5/config"

--- a/cmd/bashbrew/main.go
+++ b/cmd/bashbrew/main.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/codegangsta/cli"
 
-	"github.com/docker-library/go-dockerlibrary/manifest"
+	"github.com/docker-library/bashbrew/manifest"
 )
 
 // TODO somewhere, ensure that the Docker engine we're talking to is API version 1.22+ (Docker 1.10+)

--- a/cmd/bashbrew/repo.go
+++ b/cmd/bashbrew/repo.go
@@ -8,7 +8,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/docker-library/go-dockerlibrary/manifest"
+	"github.com/docker-library/bashbrew/manifest"
 )
 
 func repos(all bool, args ...string) ([]string, error) {

--- a/cmd/bashbrew/sort.go
+++ b/cmd/bashbrew/sort.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"github.com/docker-library/go-dockerlibrary/manifest"
+	"github.com/docker-library/bashbrew/manifest"
 	"pault.ag/go/topsort"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ go 1.11
 
 require (
 	github.com/codegangsta/cli v1.20.0
-	github.com/docker-library/go-dockerlibrary v0.0.0-20200415185511-8f28c0fe22db
 	github.com/go-git/go-git/v5 v5.1.0
 	golang.org/x/crypto v0.0.0-20200510223506-06a226fb4e37 // indirect
 	golang.org/x/net v0.0.0-20200506145744-7e3656a0809f // indirect

--- a/go.sum
+++ b/go.sum
@@ -10,8 +10,6 @@ github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ3
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/docker-library/go-dockerlibrary v0.0.0-20200415185511-8f28c0fe22db h1:qxSDuZDqrt7X9gU75CD3GliYYSMLbHcO69VP7XWmoxk=
-github.com/docker-library/go-dockerlibrary v0.0.0-20200415185511-8f28c0fe22db/go.mod h1:ijRhN3WM71dD8TfohKoUdX46BT2uz/Ek5O+5PINI880=
 github.com/emirpasic/gods v1.12.0 h1:QAUIPSaCu4G+POclxeqb3F+WPpdKqFGlw36+yOzGlrg=
 github.com/emirpasic/gods v1.12.0/go.mod h1:YfzfFFoVP/catgzJb4IKIqXjX78Ha8FMSDh3ymbK86o=
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568 h1:BHsljHzVlRcyQhjrss6TZTdY2VfCqZPbv5k3iBFa2ZQ=

--- a/manifest/example_test.go
+++ b/manifest/example_test.go
@@ -1,0 +1,209 @@
+package manifest_test
+
+import (
+	"bufio"
+	"fmt"
+	"strings"
+
+	"github.com/docker-library/bashbrew/manifest"
+)
+
+func Example() {
+	man, err := manifest.Parse(bufio.NewReader(strings.NewReader(`# RFC 2822
+
+	# I LOVE CAKE
+
+Maintainers: InfoSiftr <github@infosiftr.com> (@infosiftr),
+             Johan Euphrosine <proppy@google.com> (@proppy)
+GitFetch: refs/heads/master
+GitRepo: https://github.com/docker-library/golang.git
+SharedTags: latest
+arm64v8-GitRepo: https://github.com/docker-library/golang.git
+Architectures: amd64, amd64
+
+
+ # hi
+
+
+ 	 # blasphemer
+
+
+# Go 1.6
+Tags: 1.6.1, 1.6, 1
+arm64v8-GitRepo: https://github.com/docker-library/golang.git
+Directory: 1.6
+GitCommit: 0ce80411b9f41e9c3a21fc0a1bffba6ae761825a
+Constraints: some-random-build-server
+
+
+# Go 1.5
+Tags: 1.5.3
+GitCommit: d7e2a8d90a9b8f5dfd5bcd428e0c33b68c40cc19
+SharedTags: 1.5.3-debian, 1.5-debian
+Directory: 1.5
+s390x-GitCommit: b6c460e7cd79b595267870a98013ec3078b490df
+i386-GitFetch: refs/heads/i386
+ppc64le-Directory: 1.5/ppc64le/
+
+
+Tags: 1.5
+SharedTags: 1.5-debian
+GitCommit: d7e2a8d90a9b8f5dfd5bcd428e0c33b68c40cc19
+Directory: 1.5
+s390x-GitCommit: b6c460e7cd79b595267870a98013ec3078b490df
+i386-GitFetch: refs/heads/i386
+ppc64le-Directory: 1.5/ppc64le
+
+Tags: 1.5-alpine
+GitCommit: d7e2a8d90a9b8f5dfd5bcd428e0c33b68c40cc19
+Directory: 1.5
+File: Dockerfile.alpine
+s390x-File: Dockerfile.alpine.s390x.bad-boy
+
+SharedTags: raspbian
+GitCommit: deadbeefdeadbeefdeadbeefdeadbeefdeadbeef
+Tags: raspbian-s390x
+Architectures: s390x, i386
+File: Dockerfile-raspbian
+s390x-File: Dockerfile
+
+
+`)))
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("-------------\n2822:\n%s\n", man)
+
+	fmt.Printf("\nShared Tag Groups:\n")
+	for _, group := range man.GetSharedTagGroups() {
+		fmt.Printf("\n  - %s\n", strings.Join(group.SharedTags, ", "))
+		for _, entry := range group.Entries {
+			fmt.Printf("    - %s\n", entry.TagsString())
+		}
+	}
+	fmt.Printf("\n")
+
+	man, err = manifest.Parse(bufio.NewReader(strings.NewReader(`
+# maintainer: InfoSiftr <github@infosiftr.com> (@infosiftr)
+# maintainer: John Smith <jsmith@example.com> (@example-jsmith)
+
+# first set
+a: b@c d
+e: b@c d
+
+ # second set
+f: g@h
+i: g@h j
+`)))
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("-------------\nline-based:\n%v\n", man)
+
+	// Output:
+	// -------------
+	// 2822:
+	// Maintainers: InfoSiftr <github@infosiftr.com> (@infosiftr), Johan Euphrosine <proppy@google.com> (@proppy)
+	// SharedTags: latest
+	// GitRepo: https://github.com/docker-library/golang.git
+	// arm64v8-GitRepo: https://github.com/docker-library/golang.git
+	//
+	// Tags: 1.6.1, 1.6, 1
+	// GitCommit: 0ce80411b9f41e9c3a21fc0a1bffba6ae761825a
+	// Directory: 1.6
+	// Constraints: some-random-build-server
+	//
+	// Tags: 1.5.3, 1.5
+	// SharedTags: 1.5.3-debian, 1.5-debian
+	// GitCommit: d7e2a8d90a9b8f5dfd5bcd428e0c33b68c40cc19
+	// Directory: 1.5
+	// i386-GitFetch: refs/heads/i386
+	// ppc64le-Directory: 1.5/ppc64le
+	// s390x-GitCommit: b6c460e7cd79b595267870a98013ec3078b490df
+	//
+	// Tags: 1.5-alpine
+	// GitCommit: d7e2a8d90a9b8f5dfd5bcd428e0c33b68c40cc19
+	// Directory: 1.5
+	// File: Dockerfile.alpine
+	// s390x-File: Dockerfile.alpine.s390x.bad-boy
+	//
+	// Tags: raspbian-s390x
+	// SharedTags: raspbian
+	// Architectures: i386, s390x
+	// GitCommit: deadbeefdeadbeefdeadbeefdeadbeefdeadbeef
+	// File: Dockerfile-raspbian
+	// s390x-File: Dockerfile
+	//
+	// Shared Tag Groups:
+	//
+	//   - latest
+	//     - 1.6.1, 1.6, 1
+	//     - 1.5-alpine
+	//
+	//   - 1.5.3-debian, 1.5-debian
+	//     - 1.5.3, 1.5
+	//
+	//   - raspbian
+	//     - raspbian-s390x
+	//
+	// -------------
+	// line-based:
+	// Maintainers: InfoSiftr <github@infosiftr.com> (@infosiftr), John Smith <jsmith@example.com> (@example-jsmith)
+	// GitFetch: refs/heads/*
+	//
+	// Tags: a, e
+	// GitRepo: b
+	// GitCommit: c
+	// Directory: d
+	//
+	// Tags: f
+	// GitRepo: g
+	// GitFetch: refs/tags/h
+	// GitCommit: FETCH_HEAD
+	//
+	// Tags: i
+	// GitRepo: g
+	// GitFetch: refs/tags/h
+	// GitCommit: FETCH_HEAD
+	// Directory: j
+}
+
+func ExampleFetch_local() {
+	repoName, tagName, man, err := manifest.Fetch("testdata", "bash:4.4")
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("%s:%s\n\n", repoName, tagName)
+
+	fmt.Println(man.GetTag(tagName).ClearDefaults(manifest.DefaultManifestEntry).String())
+
+	// Output:
+	// bash:4.4
+	//
+	// Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon)
+	// Tags: 4.4.12, 4.4, 4, latest
+	// GitRepo: https://github.com/tianon/docker-bash.git
+	// GitCommit: 1cbb5cf49b4c53bd5a986abf7a1afeb9a80eac1e
+	// Directory: 4.4
+}
+
+func ExampleFetch_remote() {
+	repoName, tagName, man, err := manifest.Fetch("/home/jsmith/docker/official-images/library", "https://github.com/docker-library/official-images/raw/1a3c4cd6d5cd53bd538a6f56a69f94c5b35325a7/library/bash:4.4")
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("%s:%s\n\n", repoName, tagName)
+
+	fmt.Println(man.GetTag(tagName).ClearDefaults(manifest.DefaultManifestEntry).String())
+
+	// Output:
+	// bash:4.4
+	//
+	// Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon)
+	// Tags: 4.4.12, 4.4, 4, latest
+	// GitRepo: https://github.com/tianon/docker-bash.git
+	// GitCommit: 1cbb5cf49b4c53bd5a986abf7a1afeb9a80eac1e
+	// Directory: 4.4
+}

--- a/manifest/fetch.go
+++ b/manifest/fetch.go
@@ -1,0 +1,73 @@
+package manifest
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+func validateTagName(man *Manifest2822, repoName, tagName string) error {
+	if tagName != "" && (man.GetTag(tagName) == nil && len(man.GetSharedTag(tagName)) == 0) {
+		return fmt.Errorf("tag not found in manifest for %q: %q", repoName, tagName)
+	}
+	return nil
+}
+
+// "library" is the default "library directory"
+// returns the parsed version of (in order):
+//   if "repo" is a URL, the remote contents of that URL
+//   if "repo" is a relative path like "./repo", that file
+//   the file "library/repo"
+// (repoName, tagName, man, err)
+func Fetch(library, repo string) (string, string, *Manifest2822, error) {
+	repoName := filepath.Base(repo)
+	tagName := ""
+	if tagIndex := strings.IndexRune(repoName, ':'); tagIndex > 0 {
+		tagName = repoName[tagIndex+1:]
+		repoName = repoName[:tagIndex]
+		repo = strings.TrimSuffix(repo, ":"+tagName)
+	}
+
+	u, err := url.Parse(repo)
+	if err == nil && u.IsAbs() && (u.Scheme == "http" || u.Scheme == "https") {
+		// must be remote URL!
+		resp, err := http.Get(repo)
+		if err != nil {
+			return repoName, tagName, nil, err
+		}
+		defer resp.Body.Close()
+		man, err := Parse(resp.Body)
+		if err != nil {
+			return repoName, tagName, man, err
+		}
+		return repoName, tagName, man, validateTagName(man, repoName, tagName)
+	}
+
+	// try file paths
+	filePaths := []string{}
+	if filepath.IsAbs(repo) || strings.IndexRune(repo, filepath.Separator) >= 0 || strings.IndexRune(repo, '/') >= 0 {
+		filePaths = append(filePaths, repo)
+	}
+	if !filepath.IsAbs(repo) {
+		filePaths = append(filePaths, filepath.Join(library, repo))
+	}
+	for _, fileName := range filePaths {
+		f, err := os.Open(fileName)
+		if err != nil && !os.IsNotExist(err) {
+			return repoName, tagName, nil, err
+		}
+		if err == nil {
+			defer f.Close()
+			man, err := Parse(f)
+			if err != nil {
+				return repoName, tagName, man, err
+			}
+			return repoName, tagName, man, validateTagName(man, repoName, tagName)
+		}
+	}
+
+	return repoName, tagName, nil, fmt.Errorf("unable to find a manifest named %q (in %q or as a remote URL)", repo, library)
+}

--- a/manifest/line-based.go
+++ b/manifest/line-based.go
@@ -1,0 +1,91 @@
+package manifest
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"strings"
+)
+
+const DefaultLineBasedFetch = "refs/heads/*" // backwards compatibility
+
+// TODO write more of a proper parser? (probably not worthwhile given that 2822 is the preferred format)
+func ParseLineBasedLine(line string, defaults Manifest2822Entry) (*Manifest2822Entry, error) {
+	entry := defaults.Clone()
+
+	parts := strings.SplitN(line, ":", 2)
+	if len(parts) < 2 {
+		return nil, fmt.Errorf("manifest line missing ':': %s", line)
+	}
+	entry.Tags = []string{strings.TrimSpace(parts[0])}
+
+	parts = strings.SplitN(parts[1], "@", 2)
+	if len(parts) < 2 {
+		return nil, fmt.Errorf("manifest line missing '@': %s", line)
+	}
+	entry.GitRepo = strings.TrimSpace(parts[0])
+
+	parts = strings.SplitN(parts[1], " ", 2)
+	entry.GitCommit = strings.TrimSpace(parts[0])
+	if len(parts) > 1 {
+		entry.Directory = strings.TrimSpace(parts[1])
+	}
+
+	if entry.GitFetch == DefaultLineBasedFetch && !GitCommitRegex.MatchString(entry.GitCommit) {
+		// doesn't look like a commit, must be a tag
+		entry.GitFetch = "refs/tags/" + entry.GitCommit
+		entry.GitCommit = "FETCH_HEAD"
+	}
+
+	return &entry, nil
+}
+
+func ParseLineBased(readerIn io.Reader) (*Manifest2822, error) {
+	reader := bufio.NewReader(readerIn)
+
+	manifest := &Manifest2822{
+		Global: DefaultManifestEntry.Clone(),
+	}
+	manifest.Global.GitFetch = DefaultLineBasedFetch
+
+	for {
+		line, err := reader.ReadString('\n')
+
+		line = strings.TrimSpace(line)
+		if len(line) > 0 {
+			if line[0] == '#' {
+				maintainerLine := strings.TrimPrefix(line, "# maintainer: ")
+				if line != maintainerLine {
+					// if the prefix was removed, it must be a maintainer line!
+					manifest.Global.Maintainers = append(manifest.Global.Maintainers, maintainerLine)
+				}
+			} else {
+				entry, parseErr := ParseLineBasedLine(line, manifest.Global)
+				if parseErr != nil {
+					return nil, parseErr
+				}
+
+				err = manifest.AddEntry(*entry)
+				if err != nil {
+					return nil, err
+				}
+			}
+		}
+
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if len(manifest.Global.Maintainers) < 1 {
+		return nil, fmt.Errorf("missing Maintainers")
+	}
+	if invalidMaintainers := manifest.Global.InvalidMaintainers(); len(invalidMaintainers) > 0 {
+		return nil, fmt.Errorf("invalid Maintainers: %q (expected format %q)", strings.Join(invalidMaintainers, ", "), MaintainersFormat)
+	}
+
+	return manifest, nil
+}

--- a/manifest/parse.go
+++ b/manifest/parse.go
@@ -1,0 +1,25 @@
+package manifest
+
+import (
+	"bytes"
+	"io"
+)
+
+// try parsing as a 2822 manifest, but fallback to line-based if that fails
+func Parse(reader io.Reader) (*Manifest2822, error) {
+	buf := &bytes.Buffer{}
+
+	// try parsing as 2822, but also copy back into a new buffer so that if it fails, we can re-parse as line-based
+	manifest, err2822 := Parse2822(io.TeeReader(reader, buf))
+	if err2822 != nil {
+		manifest, err := ParseLineBased(buf)
+		if err != nil {
+			// if we fail parsing line-based, eat the error and return the 2822 parsing error instead
+			// https://github.com/docker-library/bashbrew/issues/16
+			return nil, err2822
+		}
+		return manifest, nil
+	}
+
+	return manifest, nil
+}

--- a/manifest/parse_test.go
+++ b/manifest/parse_test.go
@@ -1,0 +1,20 @@
+package manifest_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/docker-library/bashbrew/manifest"
+)
+
+func TestParseError(t *testing.T) {
+	invalidManifest := `this is just completely bogus and invalid no matter how you slice it`
+
+	man, err := manifest.Parse(strings.NewReader(invalidManifest))
+	if err == nil {
+		t.Errorf("Expected error, got valid manifest instead:\n%s", man)
+	}
+	if !strings.HasPrefix(err.Error(), "Bad line:") {
+		t.Errorf("Unexpected error: %v", err)
+	}
+}

--- a/manifest/rfc2822.go
+++ b/manifest/rfc2822.go
@@ -1,0 +1,608 @@
+package manifest
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"path"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/docker-library/bashbrew/architecture"
+	"github.com/docker-library/bashbrew/pkg/stripper"
+
+	"pault.ag/go/debian/control"
+)
+
+var (
+	GitCommitRegex = regexp.MustCompile(`^[0-9a-f]{1,64}$`)
+	GitFetchRegex  = regexp.MustCompile(`^refs/(heads|tags)/[^*?:]+$`)
+
+	// https://github.com/docker/distribution/blob/v2.7.1/reference/regexp.go#L37
+	ValidTagRegex = regexp.MustCompile(`^\w[\w.-]{0,127}$`)
+)
+
+type Manifest2822 struct {
+	Global  Manifest2822Entry
+	Entries []Manifest2822Entry
+}
+
+type Manifest2822Entry struct {
+	control.Paragraph
+
+	Maintainers []string `delim:"," strip:"\n\r\t "`
+
+	Tags       []string `delim:"," strip:"\n\r\t "`
+	SharedTags []string `delim:"," strip:"\n\r\t "`
+
+	Architectures []string `delim:"," strip:"\n\r\t "`
+
+	GitRepo   string
+	GitFetch  string
+	GitCommit string
+	Directory string
+	File      string
+
+	// architecture-specific versions of the above fields
+	ArchValues map[string]string
+	// "ARCH-FIELD: VALUE"
+	// ala, "s390x-GitCommit: deadbeef"
+	// (sourced from Paragraph.Values via .SeedArchValues())
+
+	Constraints []string `delim:"," strip:"\n\r\t "`
+}
+
+var (
+	DefaultArchitecture = "amd64"
+
+	DefaultManifestEntry = Manifest2822Entry{
+		Architectures: []string{DefaultArchitecture},
+
+		GitFetch:  "refs/heads/master",
+		Directory: ".",
+		File:      "Dockerfile",
+	}
+)
+
+func deepCopyStringsMap(a map[string]string) map[string]string {
+	b := map[string]string{}
+	for k, v := range a {
+		b[k] = v
+	}
+	return b
+}
+
+func (entry Manifest2822Entry) Clone() Manifest2822Entry {
+	// SLICES! grr
+	entry.Maintainers = append([]string{}, entry.Maintainers...)
+	entry.Tags = append([]string{}, entry.Tags...)
+	entry.SharedTags = append([]string{}, entry.SharedTags...)
+	entry.Architectures = append([]string{}, entry.Architectures...)
+	entry.Constraints = append([]string{}, entry.Constraints...)
+	// and MAPS, oh my
+	entry.ArchValues = deepCopyStringsMap(entry.ArchValues)
+	return entry
+}
+
+func (entry *Manifest2822Entry) SeedArchValues() {
+	for field, val := range entry.Paragraph.Values {
+		if strings.HasSuffix(field, "-GitRepo") || strings.HasSuffix(field, "-GitFetch") || strings.HasSuffix(field, "-GitCommit") || strings.HasSuffix(field, "-Directory") || strings.HasSuffix(field, "-File") {
+			entry.ArchValues[field] = val
+		}
+	}
+}
+func (entry *Manifest2822Entry) CleanDirectoryValues() {
+	entry.Directory = path.Clean(entry.Directory)
+	for field, val := range entry.ArchValues {
+		if strings.HasSuffix(field, "-Directory") && val != "" {
+			entry.ArchValues[field] = path.Clean(val)
+		}
+	}
+}
+
+const StringSeparator2822 = ", "
+
+func (entry Manifest2822Entry) MaintainersString() string {
+	return strings.Join(entry.Maintainers, StringSeparator2822)
+}
+
+func (entry Manifest2822Entry) TagsString() string {
+	return strings.Join(entry.Tags, StringSeparator2822)
+}
+
+func (entry Manifest2822Entry) SharedTagsString() string {
+	return strings.Join(entry.SharedTags, StringSeparator2822)
+}
+
+func (entry Manifest2822Entry) ArchitecturesString() string {
+	return strings.Join(entry.Architectures, StringSeparator2822)
+}
+
+func (entry Manifest2822Entry) ConstraintsString() string {
+	return strings.Join(entry.Constraints, StringSeparator2822)
+}
+
+// if this method returns "true", then a.Tags and b.Tags can safely be combined (for the purposes of building)
+func (a Manifest2822Entry) SameBuildArtifacts(b Manifest2822Entry) bool {
+	// check xxxarch-GitRepo, etc. fields for sameness first
+	for _, key := range append(a.archFields(), b.archFields()...) {
+		if a.ArchValues[key] != b.ArchValues[key] {
+			return false
+		}
+	}
+
+	return a.ArchitecturesString() == b.ArchitecturesString() && a.GitRepo == b.GitRepo && a.GitFetch == b.GitFetch && a.GitCommit == b.GitCommit && a.Directory == b.Directory && a.File == b.File && a.ConstraintsString() == b.ConstraintsString()
+}
+
+// returns a list of architecture-specific fields in an Entry
+func (entry Manifest2822Entry) archFields() []string {
+	ret := []string{}
+	for key, val := range entry.ArchValues {
+		if val != "" {
+			ret = append(ret, key)
+		}
+	}
+	sort.Strings(ret)
+	return ret
+}
+
+// returns a new Entry with any of the values that are equal to the values in "defaults" cleared
+func (entry Manifest2822Entry) ClearDefaults(defaults Manifest2822Entry) Manifest2822Entry {
+	entry = entry.Clone() // make absolutely certain we have a deep clone
+	if entry.MaintainersString() == defaults.MaintainersString() {
+		entry.Maintainers = nil
+	}
+	if entry.TagsString() == defaults.TagsString() {
+		entry.Tags = nil
+	}
+	if entry.SharedTagsString() == defaults.SharedTagsString() {
+		entry.SharedTags = nil
+	}
+	if entry.ArchitecturesString() == defaults.ArchitecturesString() {
+		entry.Architectures = nil
+	}
+	if entry.GitRepo == defaults.GitRepo {
+		entry.GitRepo = ""
+	}
+	if entry.GitFetch == defaults.GitFetch {
+		entry.GitFetch = ""
+	}
+	if entry.GitCommit == defaults.GitCommit {
+		entry.GitCommit = ""
+	}
+	if entry.Directory == defaults.Directory {
+		entry.Directory = ""
+	}
+	if entry.File == defaults.File {
+		entry.File = ""
+	}
+	for _, key := range defaults.archFields() {
+		if defaults.ArchValues[key] == entry.ArchValues[key] {
+			delete(entry.ArchValues, key)
+		}
+	}
+	if entry.ConstraintsString() == defaults.ConstraintsString() {
+		entry.Constraints = nil
+	}
+	return entry
+}
+
+func (entry Manifest2822Entry) String() string {
+	ret := []string{}
+	if str := entry.MaintainersString(); str != "" {
+		ret = append(ret, "Maintainers: "+str)
+	}
+	if str := entry.TagsString(); str != "" {
+		ret = append(ret, "Tags: "+str)
+	}
+	if str := entry.SharedTagsString(); str != "" {
+		ret = append(ret, "SharedTags: "+str)
+	}
+	if str := entry.ArchitecturesString(); str != "" {
+		ret = append(ret, "Architectures: "+str)
+	}
+	if str := entry.GitRepo; str != "" {
+		ret = append(ret, "GitRepo: "+str)
+	}
+	if str := entry.GitFetch; str != "" {
+		ret = append(ret, "GitFetch: "+str)
+	}
+	if str := entry.GitCommit; str != "" {
+		ret = append(ret, "GitCommit: "+str)
+	}
+	if str := entry.Directory; str != "" {
+		ret = append(ret, "Directory: "+str)
+	}
+	if str := entry.File; str != "" {
+		ret = append(ret, "File: "+str)
+	}
+	for _, key := range entry.archFields() {
+		ret = append(ret, key+": "+entry.ArchValues[key])
+	}
+	if str := entry.ConstraintsString(); str != "" {
+		ret = append(ret, "Constraints: "+str)
+	}
+	return strings.Join(ret, "\n")
+}
+
+func (manifest Manifest2822) String() string {
+	entries := []Manifest2822Entry{manifest.Global.ClearDefaults(DefaultManifestEntry)}
+	entries = append(entries, manifest.Entries...)
+
+	ret := []string{}
+	for i, entry := range entries {
+		if i > 0 {
+			entry = entry.ClearDefaults(manifest.Global)
+		}
+		ret = append(ret, entry.String())
+	}
+
+	return strings.Join(ret, "\n\n")
+}
+
+func (entry *Manifest2822Entry) SetGitRepo(arch string, repo string) {
+	if entry.ArchValues == nil {
+		entry.ArchValues = map[string]string{}
+	}
+	entry.ArchValues[arch+"-GitRepo"] = repo
+}
+
+func (entry Manifest2822Entry) ArchGitRepo(arch string) string {
+	if val, ok := entry.ArchValues[arch+"-GitRepo"]; ok && val != "" {
+		return val
+	}
+	return entry.GitRepo
+}
+
+func (entry Manifest2822Entry) ArchGitFetch(arch string) string {
+	if val, ok := entry.ArchValues[arch+"-GitFetch"]; ok && val != "" {
+		return val
+	}
+	return entry.GitFetch
+}
+
+func (entry *Manifest2822Entry) SetGitCommit(arch string, commit string) {
+	if entry.ArchValues == nil {
+		entry.ArchValues = map[string]string{}
+	}
+	entry.ArchValues[arch+"-GitCommit"] = commit
+}
+
+func (entry Manifest2822Entry) ArchGitCommit(arch string) string {
+	if val, ok := entry.ArchValues[arch+"-GitCommit"]; ok && val != "" {
+		return val
+	}
+	return entry.GitCommit
+}
+
+func (entry Manifest2822Entry) ArchDirectory(arch string) string {
+	if val, ok := entry.ArchValues[arch+"-Directory"]; ok && val != "" {
+		return val
+	}
+	return entry.Directory
+}
+
+func (entry Manifest2822Entry) ArchFile(arch string) string {
+	if val, ok := entry.ArchValues[arch+"-File"]; ok && val != "" {
+		return val
+	}
+	return entry.File
+}
+
+func (entry Manifest2822Entry) HasTag(tag string) bool {
+	for _, existingTag := range entry.Tags {
+		if tag == existingTag {
+			return true
+		}
+	}
+	return false
+}
+
+// HasSharedTag returns true if the given tag exists in entry.SharedTags.
+func (entry Manifest2822Entry) HasSharedTag(tag string) bool {
+	for _, existingTag := range entry.SharedTags {
+		if tag == existingTag {
+			return true
+		}
+	}
+	return false
+}
+
+// HasArchitecture returns true if the given architecture exists in entry.Architectures
+func (entry Manifest2822Entry) HasArchitecture(arch string) bool {
+	for _, existingArch := range entry.Architectures {
+		if arch == existingArch {
+			return true
+		}
+	}
+	return false
+}
+
+func (manifest Manifest2822) GetTag(tag string) *Manifest2822Entry {
+	for i, entry := range manifest.Entries {
+		if entry.HasTag(tag) {
+			return &manifest.Entries[i]
+		}
+	}
+	return nil
+}
+
+// GetSharedTag returns a list of entries with the given tag in entry.SharedTags (or the empty list if there are no entries with the given tag).
+func (manifest Manifest2822) GetSharedTag(tag string) []*Manifest2822Entry {
+	ret := []*Manifest2822Entry{}
+	for i, entry := range manifest.Entries {
+		if entry.HasSharedTag(tag) {
+			ret = append(ret, &manifest.Entries[i])
+		}
+	}
+	return ret
+}
+
+// GetAllSharedTags returns a list of the sum of all SharedTags in all entries of this image manifest (in the order they appear in the file).
+func (manifest Manifest2822) GetAllSharedTags() []string {
+	fakeEntry := Manifest2822Entry{}
+	for _, entry := range manifest.Entries {
+		fakeEntry.SharedTags = append(fakeEntry.SharedTags, entry.SharedTags...)
+	}
+	fakeEntry.DeduplicateSharedTags()
+	return fakeEntry.SharedTags
+}
+
+type SharedTagGroup struct {
+	SharedTags []string
+	Entries    []*Manifest2822Entry
+}
+
+// GetSharedTagGroups returns a map of shared tag groups to the list of entries they share (as described in https://github.com/docker-library/go-dockerlibrary/pull/2#issuecomment-277853597).
+func (manifest Manifest2822) GetSharedTagGroups() []SharedTagGroup {
+	inter := map[string][]string{}
+	interOrder := []string{} // order matters, and maps randomize order
+	interKeySep := ","
+	for _, sharedTag := range manifest.GetAllSharedTags() {
+		interKeyParts := []string{}
+		for _, entry := range manifest.GetSharedTag(sharedTag) {
+			interKeyParts = append(interKeyParts, entry.Tags[0])
+		}
+		interKey := strings.Join(interKeyParts, interKeySep)
+		if _, ok := inter[interKey]; !ok {
+			interOrder = append(interOrder, interKey)
+		}
+		inter[interKey] = append(inter[interKey], sharedTag)
+	}
+	ret := []SharedTagGroup{}
+	for _, tags := range interOrder {
+		group := SharedTagGroup{
+			SharedTags: inter[tags],
+			Entries:    []*Manifest2822Entry{},
+		}
+		for _, tag := range strings.Split(tags, interKeySep) {
+			group.Entries = append(group.Entries, manifest.GetTag(tag))
+		}
+		ret = append(ret, group)
+	}
+	return ret
+}
+
+func (manifest *Manifest2822) AddEntry(entry Manifest2822Entry) error {
+	if len(entry.Tags) < 1 {
+		return fmt.Errorf("missing Tags")
+	}
+	if entry.GitRepo == "" || entry.GitFetch == "" || entry.GitCommit == "" {
+		return fmt.Errorf("Tags %q missing one of GitRepo, GitFetch, or GitCommit", entry.TagsString())
+	}
+	if invalidMaintainers := entry.InvalidMaintainers(); len(invalidMaintainers) > 0 {
+		return fmt.Errorf("Tags %q has invalid Maintainers: %q (expected format %q)", entry.TagsString(), strings.Join(invalidMaintainers, ", "), MaintainersFormat)
+	}
+
+	entry.DeduplicateSharedTags()
+	entry.CleanDirectoryValues()
+
+	if invalidTags := entry.InvalidTags(); len(invalidTags) > 0 {
+		return fmt.Errorf("Tags %q has invalid (Shared)Tags: %q", entry.TagsString(), strings.Join(invalidTags, ", "))
+	}
+	if invalidArchitectures := entry.InvalidArchitectures(); len(invalidArchitectures) > 0 {
+		return fmt.Errorf("Tags %q has invalid Architectures: %q", entry.TagsString(), strings.Join(invalidArchitectures, ", "))
+	}
+
+	seenTag := map[string]bool{}
+	for _, tag := range entry.Tags {
+		if otherEntry := manifest.GetTag(tag); otherEntry != nil {
+			return fmt.Errorf("Tags %q includes duplicate tag: %q (duplicated in %q)", entry.TagsString(), tag, otherEntry.TagsString())
+		}
+		if otherEntries := manifest.GetSharedTag(tag); len(otherEntries) > 0 {
+			return fmt.Errorf("Tags %q includes tag conflicting with a shared tag: %q (shared tag in %q)", entry.TagsString(), tag, otherEntries[0].TagsString())
+		}
+		if seenTag[tag] {
+			return fmt.Errorf("Tags %q includes duplicate tag: %q", entry.TagsString(), tag)
+		}
+		seenTag[tag] = true
+	}
+	for _, tag := range entry.SharedTags {
+		if otherEntry := manifest.GetTag(tag); otherEntry != nil {
+			return fmt.Errorf("Tags %q includes conflicting shared tag: %q (duplicated in %q)", entry.TagsString(), tag, otherEntry.TagsString())
+		}
+		if seenTag[tag] {
+			return fmt.Errorf("Tags %q includes duplicate tag: %q (in SharedTags)", entry.TagsString(), tag)
+		}
+		seenTag[tag] = true
+	}
+
+	for i, existingEntry := range manifest.Entries {
+		if existingEntry.SameBuildArtifacts(entry) {
+			manifest.Entries[i].Tags = append(existingEntry.Tags, entry.Tags...)
+			manifest.Entries[i].SharedTags = append(existingEntry.SharedTags, entry.SharedTags...)
+			manifest.Entries[i].DeduplicateSharedTags()
+			return nil
+		}
+	}
+
+	manifest.Entries = append(manifest.Entries, entry)
+
+	return nil
+}
+
+const (
+	MaintainersNameRegex   = `[^\s<>()][^<>()]*`
+	MaintainersEmailRegex  = `[^\s<>()]+`
+	MaintainersGitHubRegex = `[^\s<>()]+`
+
+	MaintainersFormat = `Full Name <contact-email-or-url> (@github-handle) OR Full Name (@github-handle)`
+)
+
+var (
+	MaintainersRegex = regexp.MustCompile(`^(` + MaintainersNameRegex + `)(?:\s+<(` + MaintainersEmailRegex + `)>)?\s+[(]@(` + MaintainersGitHubRegex + `)[)]$`)
+)
+
+func (entry Manifest2822Entry) InvalidMaintainers() []string {
+	invalid := []string{}
+	for _, maintainer := range entry.Maintainers {
+		if !MaintainersRegex.MatchString(maintainer) {
+			invalid = append(invalid, maintainer)
+		}
+	}
+	return invalid
+}
+
+func (entry Manifest2822Entry) InvalidTags() []string {
+	invalid := []string{}
+	for _, tag := range append(append([]string{}, entry.Tags...), entry.SharedTags...) {
+		if !ValidTagRegex.MatchString(tag) {
+			invalid = append(invalid, tag)
+		}
+	}
+	return invalid
+}
+
+func (entry Manifest2822Entry) InvalidArchitectures() []string {
+	invalid := []string{}
+	for _, arch := range entry.Architectures {
+		if _, ok := architecture.SupportedArches[arch]; !ok {
+			invalid = append(invalid, arch)
+		}
+	}
+	return invalid
+}
+
+// DeduplicateSharedTags will remove duplicate values from entry.SharedTags, preserving order.
+func (entry *Manifest2822Entry) DeduplicateSharedTags() {
+	aggregate := []string{}
+	seen := map[string]bool{}
+	for _, tag := range entry.SharedTags {
+		if seen[tag] {
+			continue
+		}
+		seen[tag] = true
+		aggregate = append(aggregate, tag)
+	}
+	entry.SharedTags = aggregate
+}
+
+// DeduplicateArchitectures will remove duplicate values from entry.Architectures and sort the result.
+func (entry *Manifest2822Entry) DeduplicateArchitectures() {
+	aggregate := []string{}
+	seen := map[string]bool{}
+	for _, arch := range entry.Architectures {
+		if seen[arch] {
+			continue
+		}
+		seen[arch] = true
+		aggregate = append(aggregate, arch)
+	}
+	sort.Strings(aggregate)
+	entry.Architectures = aggregate
+}
+
+type decoderWrapper struct {
+	*control.Decoder
+}
+
+func (decoder *decoderWrapper) Decode(entry *Manifest2822Entry) error {
+	// reset Architectures and SharedTags so that they can be either inherited or replaced, not additive
+	sharedTags := entry.SharedTags
+	entry.SharedTags = nil
+	arches := entry.Architectures
+	entry.Architectures = nil
+
+	for {
+		err := decoder.Decoder.Decode(entry)
+		if err != nil {
+			return err
+		}
+
+		// ignore empty paragraphs (blank lines at the start, excess blank lines between paragraphs, excess blank lines at EOF)
+		if len(entry.Paragraph.Order) == 0 {
+			continue
+		}
+
+		// if we had no SharedTags or Architectures, restore our "default" (original) values
+		if len(entry.SharedTags) == 0 {
+			entry.SharedTags = sharedTags
+		}
+		if len(entry.Architectures) == 0 {
+			entry.Architectures = arches
+		}
+		entry.DeduplicateArchitectures()
+
+		// pull out any new architecture-specific values from Paragraph.Values
+		entry.SeedArchValues()
+
+		return nil
+	}
+}
+
+func Parse2822(readerIn io.Reader) (*Manifest2822, error) {
+	reader := stripper.NewCommentStripper(readerIn)
+
+	realDecoder, err := control.NewDecoder(bufio.NewReader(reader), nil)
+	if err != nil {
+		return nil, err
+	}
+	decoder := decoderWrapper{realDecoder}
+
+	manifest := Manifest2822{
+		Global: DefaultManifestEntry.Clone(),
+	}
+
+	if err := decoder.Decode(&manifest.Global); err != nil {
+		return nil, err
+	}
+	if len(manifest.Global.Maintainers) < 1 {
+		return nil, fmt.Errorf("missing Maintainers")
+	}
+	if invalidMaintainers := manifest.Global.InvalidMaintainers(); len(invalidMaintainers) > 0 {
+		return nil, fmt.Errorf("invalid Maintainers: %q (expected format %q)", strings.Join(invalidMaintainers, ", "), MaintainersFormat)
+	}
+	if len(manifest.Global.Tags) > 0 {
+		return nil, fmt.Errorf("global Tags not permitted")
+	}
+	if invalidArchitectures := manifest.Global.InvalidArchitectures(); len(invalidArchitectures) > 0 {
+		return nil, fmt.Errorf("invalid global Architectures: %q", strings.Join(invalidArchitectures, ", "))
+	}
+
+	for {
+		entry := manifest.Global.Clone()
+
+		err := decoder.Decode(&entry)
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, err
+		}
+
+		if !GitFetchRegex.MatchString(entry.GitFetch) {
+			return nil, fmt.Errorf(`Tags %q has invalid GitFetch (must be "refs/heads/..." or "refs/tags/..."): %q`, entry.TagsString(), entry.GitFetch)
+		}
+		if !GitCommitRegex.MatchString(entry.GitCommit) {
+			return nil, fmt.Errorf(`Tags %q has invalid GitCommit (must be a commit, not a tag or ref): %q`, entry.TagsString(), entry.GitCommit)
+		}
+
+		err = manifest.AddEntry(entry)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return &manifest, nil
+}

--- a/manifest/testdata/bash
+++ b/manifest/testdata/bash
@@ -1,0 +1,38 @@
+# this is a snapshot of https://github.com/docker-library/official-images/raw/1a3c4cd6d5cd53bd538a6f56a69f94c5b35325a7/library/bash
+
+# this file is generated via https://github.com/tianon/docker-bash/blob/cd1de3dfc885b3395cd354ddb988922350b092a7/generate-stackbrew-library.sh
+
+Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon)
+GitRepo: https://github.com/tianon/docker-bash.git
+
+Tags: 4.4.12, 4.4, 4, latest
+GitCommit: 1cbb5cf49b4c53bd5a986abf7a1afeb9a80eac1e
+Directory: 4.4
+
+Tags: 4.3.48, 4.3
+GitCommit: 1cbb5cf49b4c53bd5a986abf7a1afeb9a80eac1e
+Directory: 4.3
+
+Tags: 4.2.53, 4.2
+GitCommit: 1cbb5cf49b4c53bd5a986abf7a1afeb9a80eac1e
+Directory: 4.2
+
+Tags: 4.1.17, 4.1
+GitCommit: 1cbb5cf49b4c53bd5a986abf7a1afeb9a80eac1e
+Directory: 4.1
+
+Tags: 4.0.44, 4.0
+GitCommit: 4438745d601d10d300e363f24205a3ca75307803
+Directory: 4.0
+
+Tags: 3.2.57, 3.2, 3
+GitCommit: 1cbb5cf49b4c53bd5a986abf7a1afeb9a80eac1e
+Directory: 3.2
+
+Tags: 3.1.23, 3.1
+GitCommit: 1cbb5cf49b4c53bd5a986abf7a1afeb9a80eac1e
+Directory: 3.1
+
+Tags: 3.0.22, 3.0
+GitCommit: 1cbb5cf49b4c53bd5a986abf7a1afeb9a80eac1e
+Directory: 3.0

--- a/pkg/execpipe/execpipe.go
+++ b/pkg/execpipe/execpipe.go
@@ -1,0 +1,42 @@
+package execpipe
+
+import (
+	"io"
+	"os/exec"
+)
+
+// "io.ReadCloser" interface to a command's output where "Close()" is effectively "Wait()"
+type Pipe struct {
+	cmd *exec.Cmd
+	out io.ReadCloser
+}
+
+// convenience wrapper for "Run"
+func RunCommand(cmd string, args ...string) (*Pipe, error) {
+	return Run(exec.Command(cmd, args...))
+}
+
+// start "cmd", capturing stdout in a pipe (be sure to call "Close" when finished reading to reap the process)
+func Run(cmd *exec.Cmd) (*Pipe, error) {
+	pipe := &Pipe{
+		cmd: cmd,
+	}
+	if out, err := pipe.cmd.StdoutPipe(); err != nil {
+		return nil, err
+	} else {
+		pipe.out = out
+	}
+	if err := pipe.cmd.Start(); err != nil {
+		pipe.out.Close()
+		return nil, err
+	}
+	return pipe, nil
+}
+
+func (pipe *Pipe) Read(p []byte) (n int, err error) {
+	return pipe.out.Read(p)
+}
+
+func (pipe *Pipe) Close() error {
+	return pipe.cmd.Wait()
+}

--- a/pkg/execpipe/execpipe_example_test.go
+++ b/pkg/execpipe/execpipe_example_test.go
@@ -1,0 +1,26 @@
+package execpipe_test
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/docker-library/bashbrew/pkg/execpipe"
+)
+
+func Example() {
+	pipe, err := execpipe.RunCommand("go", "version")
+	if err != nil {
+		panic(err)
+	}
+	defer pipe.Close()
+
+	var buf bytes.Buffer
+	io.Copy(&buf, pipe)
+
+	fmt.Println(strings.SplitN(buf.String(), " version ", 2)[0])
+
+	// Output:
+	// go
+}

--- a/pkg/execpipe/execpipe_test.go
+++ b/pkg/execpipe/execpipe_test.go
@@ -1,0 +1,31 @@
+package execpipe_test
+
+import (
+	"os"
+	"os/exec"
+	"testing"
+
+	"github.com/docker-library/bashbrew/pkg/execpipe"
+)
+
+func TestStdoutPipeError(t *testing.T) {
+	cmd := exec.Command("nothing", "really", "matters", "in", "the", "end")
+
+	// set "Stdout" so that "cmd.StdoutPipe" fails
+	// https://golang.org/src/os/exec/exec.go?s=16834:16883#L587
+	cmd.Stdout = os.Stdout
+
+	_, err := execpipe.Run(cmd)
+	if err == nil {
+		t.Errorf("Expected execpipe.Run to fail -- it did not")
+	}
+}
+
+func TestStartError(t *testing.T) {
+	// craft a definitely-invalid command so that "cmd.Start" fails
+	// https://golang.org/src/os/exec/exec.go?s=8739:8766#L303
+	_, err := execpipe.RunCommand("nothing-really-matters-in-the-end--bogus-command")
+	if err == nil {
+		t.Errorf("Expected execpipe.RunCommand to fail -- it did not")
+	}
+}

--- a/pkg/stripper/comments.go
+++ b/pkg/stripper/comments.go
@@ -1,0 +1,54 @@
+package stripper
+
+import (
+	"bufio"
+	"bytes"
+	"io"
+	"strings"
+	"unicode"
+)
+
+type CommentStripper struct {
+	Comment    string
+	Delimiter  byte
+	Whitespace bool
+
+	r   *bufio.Reader
+	buf bytes.Buffer
+}
+
+func NewCommentStripper(r io.Reader) *CommentStripper {
+	return &CommentStripper{
+		Comment:    "#",
+		Delimiter:  '\n',
+		Whitespace: true,
+
+		r: bufio.NewReader(r),
+	}
+}
+
+func (r *CommentStripper) Read(p []byte) (int, error) {
+	for {
+		if r.buf.Len() >= len(p) {
+			return r.buf.Read(p)
+		}
+		line, err := r.r.ReadString(r.Delimiter)
+		if len(line) > 0 {
+			checkLine := line
+			if r.Whitespace {
+				checkLine = strings.TrimLeftFunc(checkLine, unicode.IsSpace)
+			}
+			if strings.HasPrefix(checkLine, r.Comment) {
+				// yay, skip this line
+				continue
+			}
+			r.buf.WriteString(line)
+		}
+		if err != nil {
+			if r.buf.Len() > 0 {
+				return r.buf.Read(p)
+			}
+			return 0, err
+		}
+	}
+}

--- a/pkg/stripper/comments_example_test.go
+++ b/pkg/stripper/comments_example_test.go
@@ -1,0 +1,32 @@
+package stripper_test
+
+import (
+	"io"
+	"os"
+	"strings"
+
+	"github.com/docker-library/bashbrew/pkg/stripper"
+)
+
+func ExampleCommentStripper() {
+	r := strings.NewReader(`
+# opening comment
+a: b
+# comment!
+c: d # not a comment
+
+# another cheeky comment
+e: f
+`)
+
+	comStrip := stripper.NewCommentStripper(r)
+
+	// using CopyBuffer to force smaller Read sizes (better testing coverage that way)
+	io.CopyBuffer(os.Stdout, comStrip, make([]byte, 32))
+
+	// Output:
+	// a: b
+	// c: d # not a comment
+	//
+	// e: f
+}

--- a/pkg/templatelib/doc.go
+++ b/pkg/templatelib/doc.go
@@ -1,0 +1,8 @@
+/*
+Package templatelib implements a group of useful functions for use with the stdlib text/template package.
+
+Usage:
+
+	tmpl, err := template.New("some-template").Funcs(templatelib.FuncMap).Parse("Hi, {{ join " " .Names }}")
+*/
+package templatelib

--- a/pkg/templatelib/lib.go
+++ b/pkg/templatelib/lib.go
@@ -1,0 +1,138 @@
+package templatelib
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"reflect"
+	"strings"
+	"text/template"
+)
+
+func swapStringsFuncBoolArgsOrder(a func(string, string) bool) func(string, string) bool {
+	return func(str1 string, str2 string) bool {
+		return a(str2, str1)
+	}
+}
+
+func thingsActionFactory(name string, actOnFirst bool, action func([]interface{}, interface{}) interface{}) func(args ...interface{}) interface{} {
+	return func(args ...interface{}) interface{} {
+		if len(args) < 1 {
+			panic(fmt.Sprintf(`%q requires at least one argument`, name))
+		}
+
+		actArgs := []interface{}{}
+		for _, val := range args {
+			v := reflect.ValueOf(val)
+
+			switch v.Kind() {
+			case reflect.Slice, reflect.Array:
+				for i := 0; i < v.Len(); i++ {
+					actArgs = append(actArgs, v.Index(i).Interface())
+				}
+			default:
+				actArgs = append(actArgs, v.Interface())
+			}
+		}
+
+		var arg interface{}
+		if actOnFirst {
+			arg = actArgs[0]
+			actArgs = actArgs[1:]
+		} else {
+			arg = actArgs[len(actArgs)-1]
+			actArgs = actArgs[:len(actArgs)-1]
+		}
+
+		return action(actArgs, arg)
+	}
+}
+
+func stringsActionFactory(name string, actOnFirst bool, action func([]string, string) string) func(args ...interface{}) interface{} {
+	return thingsActionFactory(name, actOnFirst, func(args []interface{}, arg interface{}) interface{} {
+		str := arg.(string)
+		strs := []string{}
+		for _, val := range args {
+			strs = append(strs, val.(string))
+		}
+		return action(strs, str)
+	})
+}
+
+func stringsModifierActionFactory(a func(string, string) string) func([]string, string) string {
+	return func(strs []string, str string) string {
+		for _, mod := range strs {
+			str = a(str, mod)
+		}
+		return str
+	}
+}
+
+var FuncMap = template.FuncMap{
+	// {{- $isGitHub := hasPrefix "https://github.com/" $url -}}
+	// {{- $isHtml := hasSuffix ".html" $url -}}
+	"hasPrefix": swapStringsFuncBoolArgsOrder(strings.HasPrefix),
+	"hasSuffix": swapStringsFuncBoolArgsOrder(strings.HasSuffix),
+
+	// {{- $hugeIfTrue := .SomeValue | ternary "HUGE" "not so huge" -}}
+	// if .SomeValue is truthy, $hugeIfTrue will be "HUGE"
+	// (otherwise, "not so huge")
+	"ternary": func(truthy interface{}, falsey interface{}, val interface{}) interface{} {
+		if t, ok := template.IsTrue(val); !ok {
+			panic(fmt.Sprintf(`template.IsTrue(%+v) says things are NOT OK`, val))
+		} else if t {
+			return truthy
+		} else {
+			return falsey
+		}
+	},
+
+	// First Tag: {{- .Tags | first -}}
+	// Last Tag:  {{- .Tags | last -}}
+	"first": thingsActionFactory("first", true, func(args []interface{}, arg interface{}) interface{} { return arg }),
+	"last":  thingsActionFactory("last", false, func(args []interface{}, arg interface{}) interface{} { return arg }),
+
+	// JSON data dump: {{ json . }}
+	// (especially nice for taking data and piping it to "jq")
+	// (ie "some-tool inspect --format '{{ json . }}' some-things | jq .")
+	"json": func(v interface{}) (string, error) {
+		j, err := json.Marshal(v)
+		return string(j), err
+	},
+
+	// Everybody: {{- join ", " .Names -}}
+	// Concat: {{- join "/" "https://github.com" "jsmith" "some-repo" -}}
+	"join": stringsActionFactory("join", true, strings.Join),
+
+	// {{- $mungedUrl := $url | replace "git://" "https://" | trimSuffixes ".git" -}}
+	// turns: git://github.com/jsmith/some-repo.git
+	// into: https://github.com/jsmith/some-repo
+	"trimPrefixes": stringsActionFactory("trimPrefixes", false, stringsModifierActionFactory(strings.TrimPrefix)),
+	"trimSuffixes": stringsActionFactory("trimSuffixes", false, stringsModifierActionFactory(strings.TrimSuffix)),
+	"replace": stringsActionFactory("replace", false, func(strs []string, str string) string {
+		return strings.NewReplacer(strs...).Replace(str)
+	}),
+
+	// {{- getenv "PATH" -}}
+	// {{- getenv "HOME" "no HOME set" -}}
+	// {{- getenv "HOME" "is set" "is NOT set (or is empty)" -}}
+	"getenv": thingsActionFactory("getenv", true, func(args []interface{}, arg interface{}) interface{} {
+		var (
+			val                  = os.Getenv(arg.(string))
+			setVal   interface{} = val
+			unsetVal interface{} = ""
+		)
+		if len(args) == 2 {
+			setVal, unsetVal = args[0], args[1]
+		} else if len(args) == 1 {
+			unsetVal = args[0]
+		} else if len(args) != 0 {
+			panic(fmt.Sprintf(`expected between 1 and 3 arguments to "getenv", got %d`, len(args)+1))
+		}
+		if val != "" {
+			return setVal
+		} else {
+			return unsetVal
+		}
+	}),
+}

--- a/pkg/templatelib/lib_example_test.go
+++ b/pkg/templatelib/lib_example_test.go
@@ -1,0 +1,221 @@
+package templatelib_test
+
+import (
+	"os"
+	"text/template"
+
+	"github.com/docker-library/bashbrew/pkg/templatelib"
+)
+
+func Example_prefixSuffix() {
+	tmpl, err := template.New("github-or-html").Funcs(templatelib.FuncMap).Parse(`
+		{{- . -}}
+
+		{{- if hasPrefix "https://github.com/" . -}}
+			{{- " " -}} GitHub
+		{{- end -}}
+
+		{{- if hasSuffix ".html" . -}}
+			{{- " " -}} HTML
+		{{- end -}}
+
+		{{- "\n" -}}
+	`)
+	if err != nil {
+		panic(err)
+	}
+
+	err = tmpl.Execute(os.Stdout, "https://github.com/example/example")
+	if err != nil {
+		panic(err)
+	}
+
+	err = tmpl.Execute(os.Stdout, "https://example.com/test.html")
+	if err != nil {
+		panic(err)
+	}
+
+	err = tmpl.Execute(os.Stdout, "https://example.com")
+	if err != nil {
+		panic(err)
+	}
+
+	err = tmpl.Execute(os.Stdout, "https://github.com/example/example/raw/master/test.html")
+	if err != nil {
+		panic(err)
+	}
+
+	// Output:
+	// https://github.com/example/example GitHub
+	// https://example.com/test.html HTML
+	// https://example.com
+	// https://github.com/example/example/raw/master/test.html GitHub HTML
+}
+
+func Example_ternary() {
+	tmpl, err := template.New("huge-if-true").Funcs(templatelib.FuncMap).Parse(`
+		{{- range $a := . -}}
+			{{ printf "%#v: %s\n" $a (ternary "HUGE" "not so huge" $a) }}
+		{{- end -}}
+	`)
+
+	err = tmpl.Execute(os.Stdout, []interface{}{
+		true,
+		false,
+		"true",
+		"false",
+		"",
+		nil,
+		1,
+		0,
+		9001,
+		[]bool{},
+		[]bool{false},
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	// Output:
+	// true: HUGE
+	// false: not so huge
+	// "true": HUGE
+	// "false": HUGE
+	// "": not so huge
+	// <nil>: not so huge
+	// 1: HUGE
+	// 0: not so huge
+	// 9001: HUGE
+	// []bool{}: not so huge
+	// []bool{false}: HUGE
+}
+
+func Example_firstLast() {
+	tmpl, err := template.New("first-and-last").Funcs(templatelib.FuncMap).Parse(`First: {{ . | first }}, Last: {{ . | last }}`)
+
+	err = tmpl.Execute(os.Stdout, []interface{}{
+		"a",
+		"b",
+		"c",
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	// Output:
+	// First: a, Last: c
+}
+
+func Example_json() {
+	tmpl, err := template.New("json").Funcs(templatelib.FuncMap).Parse(`
+		{{- json . -}}
+	`)
+
+	err = tmpl.Execute(os.Stdout, map[string]interface{}{
+		"a": []string{"1", "2", "3"},
+		"b": map[string]bool{"1": true, "2": false, "3": true},
+		"c": nil,
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	// Output:
+	// {"a":["1","2","3"],"b":{"1":true,"2":false,"3":true},"c":null}
+}
+
+func Example_join() {
+	tmpl, err := template.New("join").Funcs(templatelib.FuncMap).Parse(`
+		Array: {{ . | join ", " }}{{ "\n" -}}
+		Args: {{ join ", " "a" "b" "c" -}}
+	`)
+
+	err = tmpl.Execute(os.Stdout, []string{
+		"1",
+		"2",
+		"3",
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	// Output:
+	// Array: 1, 2, 3
+	// Args: a, b, c
+}
+
+func Example_trimReplaceGitToHttps() {
+	tmpl, err := template.New("git-to-https").Funcs(templatelib.FuncMap).Parse(`
+		{{- range . -}}
+			{{- . | replace "git://" "https://" | trimSuffixes ".git" }}{{ "\n" -}}
+		{{- end -}}
+	`)
+
+	err = tmpl.Execute(os.Stdout, []string{
+		"git://github.com/jsmith/some-repo.git",
+		"https://github.com/jsmith/some-repo.git",
+		"https://github.com/jsmith/some-repo",
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	// Output:
+	// https://github.com/jsmith/some-repo
+	// https://github.com/jsmith/some-repo
+	// https://github.com/jsmith/some-repo
+}
+
+func Example_trimReplaceGitToGo() {
+	tmpl, err := template.New("git-to-go").Funcs(templatelib.FuncMap).Parse(`
+		{{- range . -}}
+			{{- . | trimPrefixes "git://" "http://" "https://" "ssh://" | trimSuffixes ".git" }}{{ "\n" -}}
+		{{- end -}}
+	`)
+
+	err = tmpl.Execute(os.Stdout, []string{
+		"git://github.com/jsmith/some-repo.git",
+		"https://github.com/jsmith/some-repo.git",
+		"https://github.com/jsmith/some-repo",
+		"ssh://github.com/jsmith/some-repo.git",
+		"github.com/jsmith/some-repo",
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	// Output:
+	// github.com/jsmith/some-repo
+	// github.com/jsmith/some-repo
+	// github.com/jsmith/some-repo
+	// github.com/jsmith/some-repo
+	// github.com/jsmith/some-repo
+}
+
+func Example_getenv() {
+	tmpl, err := template.New("getenv").Funcs(templatelib.FuncMap).Parse(`
+		The FOO environment variable {{ getenv "FOO" "is set" "is not set" }}. {{- "\n" -}}
+		BAR: {{ getenv "BAR" "not set" }} {{- "\n" -}}
+		BAZ: {{ getenv "BAZ" "not set" }} {{- "\n" -}}
+		{{- $env := getenv "FOOBARBAZ" -}}
+		{{- if eq $env "" -}}
+			FOOBARBAZ {{- "\n" -}}
+		{{- end -}}
+	`)
+
+	os.Setenv("FOO", "")
+	os.Unsetenv("BAR")
+	os.Setenv("BAZ", "foobar")
+	os.Unsetenv("FOOBARBAZ")
+
+	err = tmpl.Execute(os.Stdout, nil)
+	if err != nil {
+		panic(err)
+	}
+
+	// Output:
+	// The FOO environment variable is not set.
+	// BAR: not set
+	// BAZ: foobar
+	// FOOBARBAZ
+}

--- a/pkg/templatelib/lib_test.go
+++ b/pkg/templatelib/lib_test.go
@@ -1,0 +1,42 @@
+package templatelib_test
+
+import (
+	"strings"
+	"testing"
+	"text/template"
+	"unsafe"
+
+	"github.com/docker-library/bashbrew/pkg/templatelib"
+)
+
+func TestTernaryPanic(t *testing.T) {
+	// one of the only places template.IsTrue will return "false" for the "ok" value is an UnsafePointer (hence this test)
+
+	tmpl, err := template.New("unsafe-pointer").Funcs(templatelib.FuncMap).Parse(`{{ ternary "true" "false" . }}`)
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+
+	err = tmpl.Execute(nil, unsafe.Pointer(uintptr(0)))
+	if err == nil {
+		t.Errorf("Expected error, executed successfully instead")
+	}
+	if !strings.HasSuffix(err.Error(), `template.IsTrue(<nil>) says things are NOT OK`) {
+		t.Errorf("Expected specific error, got: %v", err)
+	}
+}
+
+func TestJoinPanic(t *testing.T) {
+	tmpl, err := template.New("join-no-arg").Funcs(templatelib.FuncMap).Parse(`{{ join }}`)
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+
+	err = tmpl.Execute(nil, nil)
+	if err == nil {
+		t.Errorf("Expected error, executed successfully instead")
+	}
+	if !strings.HasSuffix(err.Error(), `"join" requires at least one argument`) {
+		t.Errorf("Expected specific error, got: %v", err)
+	}
+}


### PR DESCRIPTION
This adjusts import paths, go.mod, and adds a new "Dockerfile.test" to run the unit tests.

(and imports the full commit history)

The intent is to now deprecate the https://github.com/docker-library/go-dockerlibrary repository, since this repository is the primary consumer of that library (and it doesn't make sense to maintain friction for ourselves in updating it).