### PR TITLE
Add explicit Manifest2822Maintainer struct

### DIFF
--- a/manifest/line-based.go
+++ b/manifest/line-based.go
@@ -57,7 +57,11 @@ func ParseLineBased(readerIn io.Reader) (*Manifest2822, error) {
 				maintainerLine := strings.TrimPrefix(line, "# maintainer: ")
 				if line != maintainerLine {
 					// if the prefix was removed, it must be a maintainer line!
-					manifest.Global.Maintainers = append(manifest.Global.Maintainers, maintainerLine)
+					maintainer := Manifest2822Maintainer{}
+					if err := maintainer.UnmarshalControl(maintainerLine); err != nil {
+						return nil, err
+					}
+					manifest.Global.Maintainers = append(manifest.Global.Maintainers, maintainer)
 				}
 			} else {
 				entry, parseErr := ParseLineBasedLine(line, manifest.Global)

--- a/manifest/parse_test.go
+++ b/manifest/parse_test.go
@@ -13,8 +13,24 @@ func TestParseError(t *testing.T) {
 	man, err := manifest.Parse(strings.NewReader(invalidManifest))
 	if err == nil {
 		t.Errorf("Expected error, got valid manifest instead:\n%s", man)
+		return
 	}
 	if !strings.HasPrefix(err.Error(), "Bad line:") {
 		t.Errorf("Unexpected error: %v", err)
+		return
+	}
+}
+
+func TestInvalidMaintainer(t *testing.T) {
+	testManifest := `Maintainers: Valid Name (@valid-handle), Valid Name <valid-email> (@valid-handle), Invalid Maintainer (invalid-handle)`
+
+	man, err := manifest.Parse(strings.NewReader(testManifest))
+	if err == nil {
+		t.Errorf("Expected error, got valid manifest instead:\n%s", man)
+		return
+	}
+	if !strings.HasPrefix(err.Error(), "invalid Maintainers:") {
+		t.Errorf("Unexpected error: %v", err)
+		return
 	}
 }


### PR DESCRIPTION
This allows us to more easily/reliably generate lists of users to ping on PRs (with the goal to ping them automatically, if one of them is not the PR author).

This is technically a breaking change, but I consider myself probably the most prolific user of bashbrew format strings (which is where this breakage would exhibit itself -- `bashbrew cat` should be unaffected), and I have exactly one script broken by it.  That script was doing some processing to generate this exact data, so IMO this is a win. 😁

    bashbrew cat --format='- `{{ $.RepoName }}`:{{ range .Manifest.Global.Maintainers }} @{{ .Handle }}{{ end }}' ...

```console
$ bashbrew cat --format='- `{{ $.RepoName }}`:{{ range .Manifest.Global.Maintainers }} @{{ .Handle }}{{ end }}' bash php docker
- `bash`: @tianon
- `php`: @tianon @yosifkit
- `docker`: @tianon @yosifkit
```