### PR TITLE
Set DOCKER_DEFAULT_PLATFORM when building "FROM scratch" images

### DIFF
--- a/architecture/oci-platform.go
+++ b/architecture/oci-platform.go
@@ -1,5 +1,7 @@
 package architecture
 
+import "path"
+
 // https://github.com/opencontainers/image-spec/blob/v1.0.1/image-index.md#image-index-property-descriptions
 // see "platform" (under "manifests")
 type OCIPlatform struct {
@@ -24,4 +26,13 @@ var SupportedArches = map[string]OCIPlatform{
 	"s390x":    {OS: "linux", Architecture: "s390x"},
 
 	"windows-amd64": {OS: "windows", Architecture: "amd64"},
+}
+
+// https://pkg.go.dev/github.com/containerd/containerd/platforms
+func (p OCIPlatform) String() string {
+	return path.Join(
+		p.OS,
+		p.Architecture,
+		p.Variant,
+	)
 }

--- a/cmd/bashbrew/docker.go
+++ b/cmd/bashbrew/docker.go
@@ -237,10 +237,16 @@ func (r Repo) dockerBuildUniqueBits(entry *manifest.Manifest2822Entry) ([]string
 	return uniqueBits, nil
 }
 
-func dockerBuild(tag string, file string, context io.Reader) error {
-	args := []string{"build", "-t", tag, "-f", file, "--rm", "--force-rm"}
+func dockerBuild(tag string, file string, context io.Reader, extraEnv []string) error {
+	args := []string{"build", "--tag", tag, "--file", file, "--rm", "--force-rm"}
 	args = append(args, "-")
 	cmd := exec.Command("docker", args...)
+	if extraEnv != nil {
+		cmd.Env = append(os.Environ(), extraEnv...)
+		if debugFlag {
+			fmt.Printf("$ export %q\n", extraEnv)
+		}
+	}
 	cmd.Stdin = context
 	if debugFlag {
 		cmd.Stdout = os.Stdout

--- a/cmd/bashbrew/main.go
+++ b/cmd/bashbrew/main.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/urfave/cli"
 
+	"github.com/docker-library/bashbrew/architecture"
 	"github.com/docker-library/bashbrew/manifest"
 )
 
@@ -22,6 +23,7 @@ var (
 	defaultCache   string
 
 	arch                 string
+	ociArch              architecture.OCIPlatform
 	namespace            string
 	constraints          []string
 	exclusiveConstraints bool
@@ -165,6 +167,11 @@ func main() {
 			namespace = c.GlobalString("namespace")
 			constraints = c.GlobalStringSlice("constraint")
 			exclusiveConstraints = c.GlobalBool("exclusive-constraints")
+
+			var ok bool
+			if ociArch, ok = architecture.SupportedArches[arch]; !ok {
+				return fmt.Errorf("invalid architecture: %q", arch)
+			}
 
 			archNamespaces = map[string]string{}
 			for _, archMapping := range c.GlobalStringSlice("arch-namespace") {


### PR DESCRIPTION
This will make sure "variant" gets set properly on the resulting images if our Docker version is 20.10+.

We set this as tightly/sparingly as possible because the `--platform` flag is used for several different things inside Docker, the most visible being platform mismatch warnings/errors that we want to avoid.

Fixes #29