### PR TITLE
Added support for Windows Server 2022 to `generate.sh`

### DIFF
--- a/scripts/github-actions/generate.sh
+++ b/scripts/github-actions/generate.sh
@@ -60,6 +60,8 @@ for tag in $tags; do
 				os: (
 					if (.constraints | contains(["windowsservercore-1809"])) or (.constraints | contains(["nanoserver-1809"])) then
 						"windows-2019"
+					elif (.constraints | contains(["windowsservercore-ltsc2022"])) or (.constraints | contains(["nanoserver-ltsc2022"])) then
+						"windows-2022"
 					elif .constraints | contains(["windowsservercore-ltsc2016"]) then
 						"windows-2016"
 					elif .constraints == [] or .constraints == ["!aufs"] then

--- a/scripts/github-actions/generate.sh
+++ b/scripts/github-actions/generate.sh
@@ -58,10 +58,10 @@ for tag in $tags; do
 			{
 				name: .name,
 				os: (
-					if (.constraints | contains(["windowsservercore-1809"])) or (.constraints | contains(["nanoserver-1809"])) then
-						"windows-2019"
-					elif (.constraints | contains(["windowsservercore-ltsc2022"])) or (.constraints | contains(["nanoserver-ltsc2022"])) then
+					if (.constraints | contains(["windowsservercore-ltsc2022"])) or (.constraints | contains(["nanoserver-ltsc2022"])) then
 						"windows-2022"
+					elif (.constraints | contains(["windowsservercore-1809"])) or (.constraints | contains(["nanoserver-1809"])) then
+						"windows-2019"
 					elif .constraints | contains(["windowsservercore-ltsc2016"]) then
 						"windows-2016"
 					elif .constraints == [] or .constraints == ["!aufs"] then


### PR DESCRIPTION
Github Action has added support for Windows Server 2022 yesterday, see actions/virtual-environments/issues/3949. This PR adds support to generate.sh to return `windows-2022` when constrains contain `windowsservercore-ltsc2022`/`nanoserver-ltsc2022`.