### PR TITLE
Add BASHBREW_GENERATE_SKIP_PGP_PROXY variable to skip pgp-happy-eyeballs

### DIFF
--- a/scripts/github-actions/generate.sh
+++ b/scripts/github-actions/generate.sh
@@ -158,22 +158,22 @@ strategy="$(
 					"git clone --depth 1 https://github.com/docker-library/official-images.git -b master ~/oi",
 					"# create a dummy empty image/layer so we can --filter since= later to get a meaningful image list",
 					"{ echo FROM " + (
-						if (.os | startswith("windows-")) then
+						if .os | startswith("windows-") then
 							"mcr.microsoft.com/windows/servercore:ltsc" + (.os | ltrimstr("windows-"))
 						else
 							"busybox:latest"
 						end
 					) + "; echo RUN :; } | docker build --no-cache --tag image-list-marker -",
 					(
-						if .os | startswith("windows-") | not then
+						if (env.BASHBREW_GENERATE_SKIP_PGP_PROXY) or (.os | startswith("windows-")) then
+							empty
+						else
 							(
 								"# PGP Happy Eyeballs",
 								"git clone --depth 1 https://github.com/tianon/pgp-happy-eyeballs.git ~/phe",
 								"~/phe/hack-my-builds.sh",
 								"rm -rf ~/phe"
 							)
-						else
-							empty
 						end
 					)
 				] | join("\n")),


### PR DESCRIPTION
Closes #27

<details>
<summary>Diff (on `bash`):</summary>

```diff
$ diff -u <(GITHUB_REPOSITORY=bash ~/docker/bashbrew/scripts/github-actions/generate.sh | jq .) <(BASHBREW_GENERATE_SKIP_PGP_PROXY=1 GITHUB_REPOSITORY=bash ~/docker/bashbrew/scripts/github-actions/generate.sh | jq .)
Processing bash:devel-20210813 ...
Processing bash:5.1.8 ...
Processing bash:devel-20210813 ...
Processing bash:5.0.18 ...
Processing bash:5.1.8 ...
Processing bash:4.4.23 ...
Processing bash:5.0.18 ...
Processing bash:4.3.48 ...
Processing bash:4.4.23 ...
Processing bash:4.2.53 ...
Processing bash:4.3.48 ...
Processing bash:4.1.17 ...
Processing bash:4.2.53 ...
Processing bash:4.0.44 ...
Processing bash:4.1.17 ...
Processing bash:3.2.57 ...
Processing bash:4.0.44 ...
Processing bash:3.1.23 ...
Processing bash:3.2.57 ...
Processing bash:3.0.22 ...
Processing bash:3.1.23 ...
Processing bash:3.0.22 ...
--- /dev/fd/63	2021-08-26 16:06:00.223630567 -0700
+++ /dev/fd/62	2021-08-26 16:06:00.223630567 -0700
@@ -32,7 +32,7 @@
           "build": "docker build --tag 'bash:devel-20210813' --tag 'bash:devel' 'devel'",
           "history": "docker history 'bash:devel-20210813'",
           "test": "~/oi/test/run.sh 'bash:devel-20210813'",
-          "prepare": "git clone --depth 1 https://github.com/docker-library/official-images.git -b master ~/oi\n# create a dummy empty image/layer so we can --filter since= later to get a meaningful image list\n{ echo FROM busybox:latest; echo RUN :; } | docker build --no-cache --tag image-list-marker -\n# PGP Happy Eyeballs\ngit clone --depth 1 https://github.com/tianon/pgp-happy-eyeballs.git ~/phe\n~/phe/hack-my-builds.sh\nrm -rf ~/phe",
+          "prepare": "git clone --depth 1 https://github.com/docker-library/official-images.git -b master ~/oi\n# create a dummy empty image/layer so we can --filter since= later to get a meaningful image list\n{ echo FROM busybox:latest; echo RUN :; } | docker build --no-cache --tag image-list-marker -",
           "pull": "docker pull 'alpine:3.12'",
           "images": "docker image ls --filter since=image-list-marker"
         }
@@ -69,7 +69,7 @@
           "build": "docker build --tag 'bash:5.1.8' --tag 'bash:5.1' --tag 'bash:5' --tag 'bash:latest' '5.1'",
           "history": "docker history 'bash:5.1.8'",
           "test": "~/oi/test/run.sh 'bash:5.1.8'",
-          "prepare": "git clone --depth 1 https://github.com/docker-library/official-images.git -b master ~/oi\n# create a dummy empty image/layer so we can --filter since= later to get a meaningful image list\n{ echo FROM busybox:latest; echo RUN :; } | docker build --no-cache --tag image-list-marker -\n# PGP Happy Eyeballs\ngit clone --depth 1 https://github.com/tianon/pgp-happy-eyeballs.git ~/phe\n~/phe/hack-my-builds.sh\nrm -rf ~/phe",
+          "prepare": "git clone --depth 1 https://github.com/docker-library/official-images.git -b master ~/oi\n# create a dummy empty image/layer so we can --filter since= later to get a meaningful image list\n{ echo FROM busybox:latest; echo RUN :; } | docker build --no-cache --tag image-list-marker -",
           "pull": "docker pull 'alpine:3.12'",
           "images": "docker image ls --filter since=image-list-marker"
         }
@@ -104,7 +104,7 @@
           "build": "docker build --tag 'bash:5.0.18' --tag 'bash:5.0' '5.0'",
           "history": "docker history 'bash:5.0.18'",
           "test": "~/oi/test/run.sh 'bash:5.0.18'",
-          "prepare": "git clone --depth 1 https://github.com/docker-library/official-images.git -b master ~/oi\n# create a dummy empty image/layer so we can --filter since= later to get a meaningful image list\n{ echo FROM busybox:latest; echo RUN :; } | docker build --no-cache --tag image-list-marker -\n# PGP Happy Eyeballs\ngit clone --depth 1 https://github.com/tianon/pgp-happy-eyeballs.git ~/phe\n~/phe/hack-my-builds.sh\nrm -rf ~/phe",
+          "prepare": "git clone --depth 1 https://github.com/docker-library/official-images.git -b master ~/oi\n# create a dummy empty image/layer so we can --filter since= later to get a meaningful image list\n{ echo FROM busybox:latest; echo RUN :; } | docker build --no-cache --tag image-list-marker -",
           "pull": "docker pull 'alpine:3.12'",
           "images": "docker image ls --filter since=image-list-marker"
         }
@@ -140,7 +140,7 @@
           "build": "docker build --tag 'bash:4.4.23' --tag 'bash:4.4' --tag 'bash:4' '4.4'",
           "history": "docker history 'bash:4.4.23'",
           "test": "~/oi/test/run.sh 'bash:4.4.23'",
-          "prepare": "git clone --depth 1 https://github.com/docker-library/official-images.git -b master ~/oi\n# create a dummy empty image/layer so we can --filter since= later to get a meaningful image list\n{ echo FROM busybox:latest; echo RUN :; } | docker build --no-cache --tag image-list-marker -\n# PGP Happy Eyeballs\ngit clone --depth 1 https://github.com/tianon/pgp-happy-eyeballs.git ~/phe\n~/phe/hack-my-builds.sh\nrm -rf ~/phe",
+          "prepare": "git clone --depth 1 https://github.com/docker-library/official-images.git -b master ~/oi\n# create a dummy empty image/layer so we can --filter since= later to get a meaningful image list\n{ echo FROM busybox:latest; echo RUN :; } | docker build --no-cache --tag image-list-marker -",
           "pull": "docker pull 'alpine:3.12'",
           "images": "docker image ls --filter since=image-list-marker"
         }
@@ -175,7 +175,7 @@
           "build": "docker build --tag 'bash:4.3.48' --tag 'bash:4.3' '4.3'",
           "history": "docker history 'bash:4.3.48'",
           "test": "~/oi/test/run.sh 'bash:4.3.48'",
-          "prepare": "git clone --depth 1 https://github.com/docker-library/official-images.git -b master ~/oi\n# create a dummy empty image/layer so we can --filter since= later to get a meaningful image list\n{ echo FROM busybox:latest; echo RUN :; } | docker build --no-cache --tag image-list-marker -\n# PGP Happy Eyeballs\ngit clone --depth 1 https://github.com/tianon/pgp-happy-eyeballs.git ~/phe\n~/phe/hack-my-builds.sh\nrm -rf ~/phe",
+          "prepare": "git clone --depth 1 https://github.com/docker-library/official-images.git -b master ~/oi\n# create a dummy empty image/layer so we can --filter since= later to get a meaningful image list\n{ echo FROM busybox:latest; echo RUN :; } | docker build --no-cache --tag image-list-marker -",
           "pull": "docker pull 'alpine:3.12'",
           "images": "docker image ls --filter since=image-list-marker"
         }
@@ -210,7 +210,7 @@
           "build": "docker build --tag 'bash:4.2.53' --tag 'bash:4.2' '4.2'",
           "history": "docker history 'bash:4.2.53'",
           "test": "~/oi/test/run.sh 'bash:4.2.53'",
-          "prepare": "git clone --depth 1 https://github.com/docker-library/official-images.git -b master ~/oi\n# create a dummy empty image/layer so we can --filter since= later to get a meaningful image list\n{ echo FROM busybox:latest; echo RUN :; } | docker build --no-cache --tag image-list-marker -\n# PGP Happy Eyeballs\ngit clone --depth 1 https://github.com/tianon/pgp-happy-eyeballs.git ~/phe\n~/phe/hack-my-builds.sh\nrm -rf ~/phe",
+          "prepare": "git clone --depth 1 https://github.com/docker-library/official-images.git -b master ~/oi\n# create a dummy empty image/layer so we can --filter since= later to get a meaningful image list\n{ echo FROM busybox:latest; echo RUN :; } | docker build --no-cache --tag image-list-marker -",
           "pull": "docker pull 'alpine:3.12'",
           "images": "docker image ls --filter since=image-list-marker"
         }
@@ -245,7 +245,7 @@
           "build": "docker build --tag 'bash:4.1.17' --tag 'bash:4.1' '4.1'",
           "history": "docker history 'bash:4.1.17'",
           "test": "~/oi/test/run.sh 'bash:4.1.17'",
-          "prepare": "git clone --depth 1 https://github.com/docker-library/official-images.git -b master ~/oi\n# create a dummy empty image/layer so we can --filter since= later to get a meaningful image list\n{ echo FROM busybox:latest; echo RUN :; } | docker build --no-cache --tag image-list-marker -\n# PGP Happy Eyeballs\ngit clone --depth 1 https://github.com/tianon/pgp-happy-eyeballs.git ~/phe\n~/phe/hack-my-builds.sh\nrm -rf ~/phe",
+          "prepare": "git clone --depth 1 https://github.com/docker-library/official-images.git -b master ~/oi\n# create a dummy empty image/layer so we can --filter since= later to get a meaningful image list\n{ echo FROM busybox:latest; echo RUN :; } | docker build --no-cache --tag image-list-marker -",
           "pull": "docker pull 'alpine:3.12'",
           "images": "docker image ls --filter since=image-list-marker"
         }
@@ -280,7 +280,7 @@
           "build": "docker build --tag 'bash:4.0.44' --tag 'bash:4.0' '4.0'",
           "history": "docker history 'bash:4.0.44'",
           "test": "~/oi/test/run.sh 'bash:4.0.44'",
-          "prepare": "git clone --depth 1 https://github.com/docker-library/official-images.git -b master ~/oi\n# create a dummy empty image/layer so we can --filter since= later to get a meaningful image list\n{ echo FROM busybox:latest; echo RUN :; } | docker build --no-cache --tag image-list-marker -\n# PGP Happy Eyeballs\ngit clone --depth 1 https://github.com/tianon/pgp-happy-eyeballs.git ~/phe\n~/phe/hack-my-builds.sh\nrm -rf ~/phe",
+          "prepare": "git clone --depth 1 https://github.com/docker-library/official-images.git -b master ~/oi\n# create a dummy empty image/layer so we can --filter since= later to get a meaningful image list\n{ echo FROM busybox:latest; echo RUN :; } | docker build --no-cache --tag image-list-marker -",
           "pull": "docker pull 'alpine:3.12'",
           "images": "docker image ls --filter since=image-list-marker"
         }
@@ -316,7 +316,7 @@
           "build": "docker build --tag 'bash:3.2.57' --tag 'bash:3.2' --tag 'bash:3' '3.2'",
           "history": "docker history 'bash:3.2.57'",
           "test": "~/oi/test/run.sh 'bash:3.2.57'",
-          "prepare": "git clone --depth 1 https://github.com/docker-library/official-images.git -b master ~/oi\n# create a dummy empty image/layer so we can --filter since= later to get a meaningful image list\n{ echo FROM busybox:latest; echo RUN :; } | docker build --no-cache --tag image-list-marker -\n# PGP Happy Eyeballs\ngit clone --depth 1 https://github.com/tianon/pgp-happy-eyeballs.git ~/phe\n~/phe/hack-my-builds.sh\nrm -rf ~/phe",
+          "prepare": "git clone --depth 1 https://github.com/docker-library/official-images.git -b master ~/oi\n# create a dummy empty image/layer so we can --filter since= later to get a meaningful image list\n{ echo FROM busybox:latest; echo RUN :; } | docker build --no-cache --tag image-list-marker -",
           "pull": "docker pull 'alpine:3.12'",
           "images": "docker image ls --filter since=image-list-marker"
         }
@@ -351,7 +351,7 @@
           "build": "docker build --tag 'bash:3.1.23' --tag 'bash:3.1' '3.1'",
           "history": "docker history 'bash:3.1.23'",
           "test": "~/oi/test/run.sh 'bash:3.1.23'",
-          "prepare": "git clone --depth 1 https://github.com/docker-library/official-images.git -b master ~/oi\n# create a dummy empty image/layer so we can --filter since= later to get a meaningful image list\n{ echo FROM busybox:latest; echo RUN :; } | docker build --no-cache --tag image-list-marker -\n# PGP Happy Eyeballs\ngit clone --depth 1 https://github.com/tianon/pgp-happy-eyeballs.git ~/phe\n~/phe/hack-my-builds.sh\nrm -rf ~/phe",
+          "prepare": "git clone --depth 1 https://github.com/docker-library/official-images.git -b master ~/oi\n# create a dummy empty image/layer so we can --filter since= later to get a meaningful image list\n{ echo FROM busybox:latest; echo RUN :; } | docker build --no-cache --tag image-list-marker -",
           "pull": "docker pull 'alpine:3.12'",
           "images": "docker image ls --filter since=image-list-marker"
         }
@@ -386,7 +386,7 @@
           "build": "docker build --tag 'bash:3.0.22' --tag 'bash:3.0' '3.0'",
           "history": "docker history 'bash:3.0.22'",
           "test": "~/oi/test/run.sh 'bash:3.0.22'",
-          "prepare": "git clone --depth 1 https://github.com/docker-library/official-images.git -b master ~/oi\n# create a dummy empty image/layer so we can --filter since= later to get a meaningful image list\n{ echo FROM busybox:latest; echo RUN :; } | docker build --no-cache --tag image-list-marker -\n# PGP Happy Eyeballs\ngit clone --depth 1 https://github.com/tianon/pgp-happy-eyeballs.git ~/phe\n~/phe/hack-my-builds.sh\nrm -rf ~/phe",
+          "prepare": "git clone --depth 1 https://github.com/docker-library/official-images.git -b master ~/oi\n# create a dummy empty image/layer so we can --filter since= later to get a meaningful image list\n{ echo FROM busybox:latest; echo RUN :; } | docker build --no-cache --tag image-list-marker -",
           "pull": "docker pull 'alpine:3.12'",
           "images": "docker image ls --filter since=image-list-marker"
         }
```

</details>