### PR TITLE
Add "ociPlatform" template function

### DIFF
--- a/cmd/bashbrew/cmd-cat.go
+++ b/cmd/bashbrew/cmd-cat.go
@@ -7,9 +7,10 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/urfave/cli"
+	"github.com/docker-library/bashbrew/architecture"
 	"github.com/docker-library/bashbrew/manifest"
 	"github.com/docker-library/bashbrew/pkg/templatelib"
+	"github.com/urfave/cli"
 )
 
 var DefaultCatFormat = `
@@ -54,6 +55,12 @@ func cmdCat(c *cli.Context) error {
 		},
 		"arch": func() string {
 			return arch
+		},
+		"ociPlatform": func(arch string) *architecture.OCIPlatform {
+			if ociArch, ok := architecture.SupportedArches[arch]; ok {
+				return &ociArch
+			}
+			return nil
 		},
 		"namespace": func() string {
 			return namespace


### PR DESCRIPTION
This will allow us to convert from `Architectures:` values directly to `--platform` values (for `docker pull`, etc).

This is going to be especially useful for updating https://github.com/docker-library/oi-janky-groovy/tree/master/repo-info/local with/for https://github.com/docker-library/repo-info/pull/59 (although isn't directly tied, since we're technically broken as-is right now).