### PR TITLE
Buildkit support with buildx

### DIFF
--- a/cmd/bashbrew/docker.go
+++ b/cmd/bashbrew/docker.go
@@ -276,9 +276,14 @@ func dockerBuild(tag string, file string, context io.Reader, platform string) er
 	}
 }
 
-const dockerfileSyntax = "docker/dockerfile:1"
+const dockerfileSyntaxEnv = "BASHBREW_BUILDKIT_SYNTAX"
 
 func dockerBuildxBuild(tag string, file string, context io.Reader, platform string) error {
+	dockerfileSyntax, ok := os.LookupEnv(dockerfileSyntaxEnv)
+	if !ok {
+		return fmt.Errorf("missing %q", dockerfileSyntaxEnv)
+	}
+
 	args := []string{
 		"buildx",
 		"build",

--- a/manifest/rfc2822.go
+++ b/manifest/rfc2822.go
@@ -43,6 +43,7 @@ type Manifest2822Entry struct {
 	GitCommit string
 	Directory string
 	File      string
+	Builder   string
 
 	// architecture-specific versions of the above fields
 	ArchValues map[string]string
@@ -93,7 +94,7 @@ func (entry Manifest2822Entry) Clone() Manifest2822Entry {
 
 func (entry *Manifest2822Entry) SeedArchValues() {
 	for field, val := range entry.Paragraph.Values {
-		if strings.HasSuffix(field, "-GitRepo") || strings.HasSuffix(field, "-GitFetch") || strings.HasSuffix(field, "-GitCommit") || strings.HasSuffix(field, "-Directory") || strings.HasSuffix(field, "-File") {
+		if strings.HasSuffix(field, "-GitRepo") || strings.HasSuffix(field, "-GitFetch") || strings.HasSuffix(field, "-GitCommit") || strings.HasSuffix(field, "-Directory") || strings.HasSuffix(field, "-File") || strings.HasSuffix(field, "-Builder") {
 			entry.ArchValues[field] = val
 		}
 	}
@@ -142,7 +143,7 @@ func (a Manifest2822Entry) SameBuildArtifacts(b Manifest2822Entry) bool {
 		}
 	}
 
-	return a.ArchitecturesString() == b.ArchitecturesString() && a.GitRepo == b.GitRepo && a.GitFetch == b.GitFetch && a.GitCommit == b.GitCommit && a.Directory == b.Directory && a.File == b.File && a.ConstraintsString() == b.ConstraintsString()
+	return a.ArchitecturesString() == b.ArchitecturesString() && a.GitRepo == b.GitRepo && a.GitFetch == b.GitFetch && a.GitCommit == b.GitCommit && a.Directory == b.Directory && a.File == b.File && a.Builder == b.Builder && a.ConstraintsString() == b.ConstraintsString()
 }
 
 // returns a list of architecture-specific fields in an Entry
@@ -187,6 +188,9 @@ func (entry Manifest2822Entry) ClearDefaults(defaults Manifest2822Entry) Manifes
 	if entry.File == defaults.File {
 		entry.File = ""
 	}
+	if entry.Builder == defaults.Builder {
+		entry.Builder = ""
+	}
 	for _, key := range defaults.archFields() {
 		if defaults.ArchValues[key] == entry.ArchValues[key] {
 			delete(entry.ArchValues, key)
@@ -226,6 +230,9 @@ func (entry Manifest2822Entry) String() string {
 	}
 	if str := entry.File; str != "" {
 		ret = append(ret, "File: "+str)
+	}
+	if str := entry.Builder; str != "" {
+		ret = append(ret, "Builder: "+str)
 	}
 	for _, key := range entry.archFields() {
 		ret = append(ret, key+": "+entry.ArchValues[key])
@@ -298,6 +305,13 @@ func (entry Manifest2822Entry) ArchFile(arch string) string {
 		return val
 	}
 	return entry.File
+}
+
+func (entry Manifest2822Entry) ArchBuilder(arch string) string {
+	if val, ok := entry.ArchValues[arch+"-Builder"]; ok && val != "" {
+		return val
+	}
+	return entry.Builder
 }
 
 func (entry Manifest2822Entry) HasTag(tag string) bool {


### PR DESCRIPTION
Heya :wave:

This isn't in a completed state yet, but thought it might be quicker to have a discussion around a PoC I was hacking around with, than to have a long-winded proposal :smile:

TL;DR, proposal: official images could opt in to buildkit with a syntax like:
```
Buildkit: true
```

In this case, instead of building using `docker build`, the image is built using `docker buildx build`. At some point, the default builder [will likely switch to buildkit](https://github.com/moby/moby/issues/40379), but it might be nice to start allowing some images to opt-in sooner, to reduce the complexity of adapting many images later down the road (ideally no changes would be needed in any of the Dockerfiles, but I haven't had the time to manually review every single one of them :cry:). Additionally, this could open up some nice opportunities, like being able to use the buildkit parser for extracting `FROM` data (since it's backwards compatible with older dockerfiles), using the new imagetools for manifest management, etc.

Regarding caching, buildkit has a few cache backends, and while it might be worth investigating using them in the future: but for a first pass, I think the inline cache option is most similar to what the other builder uses - this means that no separate cache policy will need to exist, it can be the same. Additionally, buildkit has good support for caching multi-stage images - which might be nice to investigate later down the road :tada:

This would let image maintainers use some newer buildkit features if they want, and hopefully unlock some future performance gains (though I haven't done any benchmarking to test yet).

Looking forward to hearing what you think!