### PR TITLE
Add explicit support to GitHub Actions scripts for ".test/config.sh" …

### DIFF
--- a/scripts/github-actions/generate.sh
+++ b/scripts/github-actions/generate.sh
@@ -96,7 +96,14 @@ for tag in $tags; do
 						| join(" ")
 					),
 					history: ("docker history " + (.tags[0] | @sh)),
-					test: ("~/oi/test/run.sh " + (.tags[0] | @sh)),
+					test: (
+						[
+							"set -- " + (.tags[0] | @sh),
+							# https://github.com/docker-library/bashbrew/issues/46#issuecomment-1152567694 (allow local test config / tests)
+							"if [ -s ./.test/config.sh ]; then set -- --config ~/oi/test/config.sh --config ./.test/config.sh \"$@\"; fi",
+							"~/oi/test/run.sh \"$@\""
+						] | join("\n")
+					),
 				},
 			}
 		'


### PR DESCRIPTION
…(and ".test/tests/xxx/")

Tested successfully via https://github.com/tianon/dockerfiles/pull/223 :smile:

Closes https://github.com/docker-library/bashbrew/issues/46

If `.test/config.sh` exists, it will be injected via `--config` on `test/run.sh`, which then also allows for additional tests in `.test/tests/foo/run.sh`.