### PR TITLE
Implement JSON string escape in pure-awk (several orders of magnitude faster)

### DIFF
--- a/scripts/jq-template.awk
+++ b/scripts/jq-template.awk
@@ -3,18 +3,13 @@
 # see https://github.com/docker-library/php or https://github.com/docker-library/golang for examples of usage ("apply-templates.sh")
 
 # escape an arbitrary string for passing back to jq as program input
-function jq_escape(str,          # parameters
-                   prog, e, out) # locals
-{
-	prog = "jq --raw-input --slurp ."
-	printf "%s", str |& prog
-	close(prog, "to")
-	prog |& getline out
-	e = close(prog)
-	if (e != 0) {
-		exit(e)
-	}
-	return out
+function jq_escape(str) {
+	gsub(/\\/, "\\\\", str)
+	gsub(/\n/, "\\n", str)
+	gsub(/\r/, "\\r", str)
+	gsub(/\t/, "\\t", str)
+	gsub(/"/, "\\\"", str)
+	return "\"" str "\""
 }
 
 # return the number of times needle appears in haystack


### PR DESCRIPTION
I've got a very pathological branch of a certain repository where this makes a parallelized (four concurrent invocations) generation change from ~3 _minutes_ down to ~13 _seconds_.

I did not implement `\b` or `\f` because I don't think the chances of them occurring naturally in a text document (especially a `Dockerfile`) in 2022+ are very high. :sweat_smile:

(Also, this isn't required to be pure JSON, but rather "`jq` compatible" as it's used as `jq` syntax so we have a little bit more wiggle room as `jq` is more forgiving than a pure strict parser)