### PR TITLE
Add "bashbrew fetch" command

### DIFF
--- a/cmd/bashbrew/cmd-cat.go
+++ b/cmd/bashbrew/cmd-cat.go
@@ -56,6 +56,13 @@ func cmdCat(c *cli.Context) error {
 		"arch": func() string {
 			return arch
 		},
+		"gitCache": func() (string, error) {
+			err := ensureGitInit()
+			if err != nil {
+				return "", err
+			}
+			return gitCache(), nil
+		},
 		"ociPlatform": func(arch string) *architecture.OCIPlatform {
 			if ociArch, ok := architecture.SupportedArches[arch]; ok {
 				return &ociArch

--- a/cmd/bashbrew/cmd-fetch.go
+++ b/cmd/bashbrew/cmd-fetch.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/urfave/cli"
+)
+
+func cmdFetch(c *cli.Context) error {
+	repos, err := repos(c.Bool("all"), c.Args()...)
+	if err != nil {
+		return cli.NewMultiError(fmt.Errorf(`failed gathering repo list`), err)
+	}
+
+	applyConstraints := c.Bool("apply-constraints")
+	archFilter := c.Bool("arch-filter")
+
+	for _, repo := range repos {
+		r, err := fetch(repo)
+		if err != nil {
+			return cli.NewMultiError(fmt.Errorf(`failed fetching repo %q`, repo), err)
+		}
+
+		for _, entry := range r.Entries() {
+			if applyConstraints && r.SkipConstraints(entry) {
+				continue
+			}
+			if archFilter && !entry.HasArchitecture(arch) {
+				continue
+			}
+
+			arches := entry.Architectures
+			if applyConstraints || archFilter {
+				arches = []string{arch}
+			}
+
+			for _, entryArch := range arches {
+				commit, err := r.fetchGitRepo(entryArch, entry)
+				if err != nil {
+					return cli.NewMultiError(fmt.Errorf(`failed fetching git repo for %q (tags %q on arch %q)`, r.RepoName, entry.TagsString(), entryArch), err)
+				}
+				if debugFlag {
+					fmt.Fprintf(os.Stderr, "DEBUG: fetched %s (%q, %q)\n", commit, r.EntryIdentifier(entry), entryArch)
+				}
+			}
+		}
+	}
+
+	return nil
+}

--- a/cmd/bashbrew/main.go
+++ b/cmd/bashbrew/main.go
@@ -403,6 +403,19 @@ func main() {
 			Category: "plumbing",
 		},
 		{
+			Name:  "fetch",
+			Usage: "ensure Git contents are local",
+			Flags: []cli.Flag{
+				commonFlags["all"],
+				commonFlags["apply-constraints"],
+				commonFlags["arch-filter"],
+			},
+			Before: subcommandBeforeFactory("fetch"),
+			Action: cmdFetch,
+
+			Category: "plumbing",
+		},
+		{
 			Name:     "remote",
 			Usage:    "query registries for bashbrew-related data",
 			Before:   subcommandBeforeFactory("remote"),


### PR DESCRIPTION
In many, many, many scripts I have encoded the horrible assumption that `ArchDockerFroms` will ensure our Git repository is fetched (which is a side-effect of that function).  With the implementation of `Builder: oci-import`, that side effect is not necessary for returning an accurate result in these new images.  Instead of working around this in bad ways, I've decided to finally bite the bullet and add an explicit `bashbrew fetch` command that can make sure all the underlying Git commits are fully fetched into the local cache.