### PR TITLE
Add more context to "git fetch" failures

### DIFF
--- a/cmd/bashbrew/git.go
+++ b/cmd/bashbrew/git.go
@@ -254,13 +254,14 @@ func (r Repo) fetchGitRepo(arch string, entry *manifest.Manifest2822Entry) (stri
 			//Progress: os.Stdout,
 		})
 		if err != nil {
-			fetchErrors = append(fetchErrors, err)
+			fetchErrors = append(fetchErrors, fmt.Errorf("failed fetching %q: %w", fetchString, err))
 			continue
 		}
 
-		commit, err = getGitCommit(entry.ArchGitCommit(arch))
+		archCommit := entry.ArchGitCommit(arch)
+		commit, err = getGitCommit(archCommit)
 		if err != nil {
-			fetchErrors = append(fetchErrors, err)
+			fetchErrors = append(fetchErrors, fmt.Errorf("failed finding Git commit %q after fetching %q: %w", archCommit, fetchString, err))
 			continue
 		}
 


### PR DESCRIPTION
This makes it a lot easier to see/debug what's going wrong:

```console
$ BASHBREW_CACHE=/tmp/foo bashbrew fetch --arch-filter ubuntu:bionic
failed fetching git repo for "ubuntu" (tags "18.04, bionic-20230126, bionic" on arch "amd64")
failed fetching "f127810992c0981574cc137b9c83937ca1a304dc:refs/remotes/temp3848952252/temp": server does not support exact SHA1 refspec
failed finding Git commit "f127810992c0981574cc137b9c83937ca1a304dc" after fetching "refs/tags/dist-bionic-amd64-20230126:refs/remotes/temp3848952252/temp": object not found
```

See also https://github.com/docker-library/official-images/pull/13968 and https://github.com/docker-library/official-images/pull/14094, especially https://github.com/docker-library/official-images/pull/14094#issuecomment-1432129628