### PR TITLE
Add support for BASHBREW_BUILDKIT_SBOM_GENERATOR and provenance

### DIFF
--- a/cmd/bashbrew/cmd-list.go
+++ b/cmd/bashbrew/cmd-list.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"path"
 
-	"github.com/urfave/cli"
 	"github.com/docker-library/bashbrew/manifest"
+	"github.com/urfave/cli"
 )
 
 func cmdList(c *cli.Context) error {

--- a/cmd/bashbrew/cmd-parents.go
+++ b/cmd/bashbrew/cmd-parents.go
@@ -33,7 +33,7 @@ func cmdParents(c *cli.Context) error {
 				if err != nil {
 					var (
 						manifestNotFoundErr manifest.ManifestNotFoundError
-						tagNotFoundErr manifest.TagNotFoundError
+						tagNotFoundErr      manifest.TagNotFoundError
 					)
 					if d != depth && (errors.As(err, &manifestNotFoundErr) || errors.As(err, &tagNotFoundErr)) {
 						// if this repo isn't one of the original top-level arguments and our error is just that it's not a supported tag, walk no further ("FROM mcr.microsoft.com/...", etc)

--- a/cmd/bashbrew/config.go
+++ b/cmd/bashbrew/config.go
@@ -8,8 +8,8 @@ import (
 	"os"
 	"strings"
 
-	"github.com/urfave/cli"
 	"github.com/docker-library/bashbrew/pkg/stripper"
+	"github.com/urfave/cli"
 	"pault.ag/go/debian/control"
 )
 

--- a/cmd/bashbrew/containerd.go
+++ b/cmd/bashbrew/containerd.go
@@ -42,7 +42,7 @@ var containerdClientCache *containerd.Client = nil
 
 // the returned client is cached, don't Close() it!
 func newContainerdClient(ctx context.Context) (context.Context, *containerd.Client, error) {
-	ns := "bashbrew"
+	ns := "bashbrew-" + arch
 	for _, envKey := range []string{
 		`BASHBREW_CONTAINERD_NAMESPACE`,
 		`CONTAINERD_NAMESPACE`,

--- a/pkg/gitfs/fs.go
+++ b/pkg/gitfs/fs.go
@@ -118,9 +118,10 @@ func (fs gitFS) Stat(name string) (fs.FileInfo, error) {
 
 // https://pkg.go.dev/io/fs#File
 type gitFSFile struct {
-	stat fs.FileInfo
+	stat   fs.FileInfo
 	reader io.ReadCloser
 }
+
 func (f gitFSFile) Stat() (fs.FileInfo, error) {
 	return f.stat, nil
 }

--- a/registry/docker-auth.go
+++ b/registry/docker-auth.go
@@ -116,6 +116,8 @@ func NewDockerAuthResolver() remotes.Resolver {
 							config,
 						}, nil
 					}
+				} else if strings.Contains(domain, "localhost") {
+					config.Scheme = "http"
 				}
 				return []dockerremote.RegistryHost{config}, nil
 			},


### PR DESCRIPTION
Since Docker's image store can't represent these, we round trip them through our self-managed (or external) containerd image store, which also makes pushing more efficient.

This very notably also requires setting `BUILDX_BUILDER` to point to an SBOM/provenance-supporting buildx builder, which is not great but I think is fine for now (we'll manage the lifecycle of that in our Jenkins infra somehow).

(Unrelated changes are `gofmt` updates we've missed previously :see_no_evil: :innocent:)