### PR TITLE
Bump go version to 1.20

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.18-bullseye AS build
+FROM golang:1.20-bullseye AS build
 
 SHELL ["bash", "-Eeuo", "pipefail", "-xc"]
 

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -1,4 +1,4 @@
-FROM golang:1.18-bullseye
+FROM golang:1.20-bullseye
 
 SHELL ["bash", "-Eeuo", "pipefail", "-xc"]
 

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,4 +1,4 @@
-FROM golang:1.18-bullseye
+FROM golang:1.20-bullseye
 
 SHELL ["bash", "-Eeuo", "pipefail", "-xc"]
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/docker-library/bashbrew
 
-go 1.18
+go 1.20
 
 require (
 	github.com/containerd/containerd v1.6.19


### PR DESCRIPTION
Just a regular go version bump to keep us on a supported version.