### PR TITLE
Add "--build-order" to cat (and a couple minor bugfixes)

### DIFF
--- a/cmd/bashbrew/cmd-cat.go
+++ b/cmd/bashbrew/cmd-cat.go
@@ -36,6 +36,14 @@ func cmdCat(c *cli.Context) error {
 	format := c.String("format")
 	formatFile := c.String("format-file")
 
+	buildOrder := c.Bool("build-order")
+	if buildOrder {
+		repos, err = sortRepos(repos, false) // do not (cannot) applyConstraints (we'd have to modify the actual objects to remove Entries)
+		if err != nil {
+			return cli.NewMultiError(fmt.Errorf(`failed sorting repo list`), err)
+		}
+	}
+
 	templateName := "--format"
 	tmplMultiErr := fmt.Errorf(`failed parsing --format %q`, format)
 	if formatFile != "" {

--- a/cmd/bashbrew/cmd-remote-arches.go
+++ b/cmd/bashbrew/cmd-remote-arches.go
@@ -22,12 +22,12 @@ func cmdRemoteArches(c *cli.Context) error {
 	for _, arg := range args {
 		img, err := registry.Resolve(ctx, arg)
 		if err != nil {
-			return err
+			return fmt.Errorf("failed to resolve %s: %w", arg, err)
 		}
 
 		arches, err := img.Architectures(ctx)
 		if err != nil {
-			return err
+			return fmt.Errorf("failed to query arches of %s: %w", arg, err)
 		}
 
 		if doJson {

--- a/cmd/bashbrew/main.go
+++ b/cmd/bashbrew/main.go
@@ -188,6 +188,10 @@ func main() {
 
 			archNamespaces = map[string]string{}
 			for _, archMapping := range c.GlobalStringSlice("arch-namespace") {
+				if archMapping == "" {
+					// "BASHBREW_ARCH_NAMESPACES=" (should be the same as the empty list)
+					continue
+				}
 				splitArchMapping := strings.SplitN(archMapping, "=", 2)
 				splitArch, splitNamespace := strings.TrimSpace(splitArchMapping[0]), strings.TrimSpace(splitArchMapping[1])
 				archNamespaces[splitArch] = splitNamespace
@@ -224,6 +228,10 @@ func main() {
 			Name:  "arch-filter",
 			Usage: "like apply-constraints, but only for Architectures",
 		},
+		"build-order": cli.BoolFlag{
+			Name:  "build-order",
+			Usage: "sort by the order repos would need to build (topsort)",
+		},
 		"depth": cli.IntFlag{
 			Name:  "depth",
 			Value: 0,
@@ -258,10 +266,7 @@ func main() {
 				commonFlags["uniq"],
 				commonFlags["apply-constraints"],
 				commonFlags["arch-filter"],
-				cli.BoolFlag{
-					Name:  "build-order",
-					Usage: "sort by the order repos would need to build (topsort)",
-				},
+				commonFlags["build-order"],
 				cli.BoolFlag{
 					Name:  "repos",
 					Usage: `list only repos, not repo:tag (unless "repo:tag" is explicitly specified)`,
@@ -380,6 +385,7 @@ func main() {
 					Name:  "format-file, F",
 					Usage: "use the contents of `FILE` for \"--format\"",
 				},
+				commonFlags["build-order"],
 			},
 			Before: subcommandBeforeFactory("cat"),
 			Action: cmdCat,


### PR DESCRIPTION
- fix parsing of empty `BASHBREW_ARCH_NAMESPACES`
- better (more contextual) error messages from `bashbrew remote arches`