### PR TITLE
Update "munge-i386" to add "--build-context" in "docker buildx build" lines

### DIFF
--- a/scripts/github-actions/munge-i386.sh
+++ b/scripts/github-actions/munge-i386.sh
@@ -21,6 +21,6 @@ jq --arg dpkgSmokeTest '[ "$(dpkg --print-architecture)" = "amd64" ]' '
 			)
 		] | join("\n"))
 		# adjust "docker buildx build" lines to include appropriate "--build-context" flags (https://github.com/docker/buildx/pull/1886)
-		| .runs.build |= gsub("docker buildx build "; "docker buildx build " + ($froms | unique | map(@sh "--build-context \(.)=docker-image://\("i386/" + .)") | join(" ")) + " ")
+		| .runs.build |= ( gsub("docker buildx build "; "docker buildx build " + ($froms | unique | map(@sh "--build-context \(.)=docker-image://\("i386/" + .)") | join(" ")) + " ") | gsub( "--platform[= ]linux/[^ ]+"; "--platform linux/386") )
 	]
 ' "$@"


### PR DESCRIPTION
Without this, we end up building against the wrong image due to a bug in buildx/buildkit (https://github.com/docker/buildx/pull/1886). 😞