### PR TITLE
Add "--platform" to GHA generate script

### DIFF
--- a/scripts/github-actions/generate.sh
+++ b/scripts/github-actions/generate.sh
@@ -53,7 +53,8 @@ for tag in $tags; do
 				"file": {{- json ($e.ArchFile $arch) -}},
 				"builder": {{- json ($e.ArchBuilder $arch) -}},
 				"constraints": {{- json $e.Constraints -}},
-				"froms": {{- json ($.ArchDockerFroms $arch $e) -}}
+				"froms": {{- json ($.ArchDockerFroms $arch $e) -}},
+				"platform": {{- json (ociPlatform $arch).String -}}
 			{{- "}" -}}
 		' "$bashbrewImage" | jq -c '
 			{
@@ -83,6 +84,10 @@ for tag in $tags; do
 							else
 								"echo >&2 " + ("error: unknown/unsupported builder: " + .builder | @sh) + "\nexit 1\n#"
 							end
+						]
+						+ [
+							# TODO error out on unsupported platforms, or just let the emulation go wild?
+							"--platform", .platform
 						]
 						+ (
 							.tags


### PR DESCRIPTION
I discovered this was missing when I created a riscv64-only image and it then failed to build on amd64. 😅

It should be totally harmless on most repos since I don't think anyone but me using this script has images that don't support one of either amd64 or windows-amd64, which will automatically be preferred. :see_no_evil: