### PR TITLE
Add workaround for "bashbrew children" with SharedTags in FROM/--from=

### DIFF
--- a/cmd/bashbrew/cmd-children.go
+++ b/cmd/bashbrew/cmd-children.go
@@ -41,9 +41,12 @@ func cmdChildren(c *cli.Context) error {
 				continue
 			}
 
+			// TODO this is buggy with respect to SharedTags, but it's really complicated to fix correctly (essentially, the shared tags become "owned" by one specific leg of the shared set, which is then hard to reconcile -- use "--arch-filter" if you want SharedTags to work [more] correctly [caveat Windows, where we can't know which leg to assign them to; perhaps full "--apply-constaints" there])
 			tags := r.Tags(namespace, false, entry)
 			for _, tag := range tags {
-				canonical[tag] = tags[0]
+				if _, ok := canonical[tag]; !ok { // again, see the note above -- this is a hack that makes it "work" in the common case of the Linux tags being listed first and those being the ones we're interested in (so they "own" the shared tags and don't get clobbered), and that's *mostly* safe because we enforce that any Windows image needs to be FROM an explicit Windows base/kernel version (not a shared tag) anyways, but it's still pretty hacky/sketchy and the algorithm here probably needs (yet another, maybe minor?) redesign 😭
+					canonical[tag] = tags[0]
+				}
 			}
 
 			entryArches := []string{arch}


### PR DESCRIPTION
There's some hopefully good code comments describing this better, but essentially this changes the algorithm to have the "first" tag/entry in the SharedTag group be the "owner" of all the shared tags (instead of the following tags clobbering that and them thus being "owned" by the final Windows entry).

Before (finding tags which have both Debian *and* Ubuntu in their parentage):

```console
$ comm -12 <(bashbrew children debian | sort) <(bashbrew children ubuntu | sort) | cut -d: -f1 | sort -u
$ # (empty list, but adding "--arch-filter" makes it work:)
$ comm -12 <(bashbrew children --arch-filter debian | sort) <(bashbrew children --arch-filter ubuntu | sort) | cut -d: -f1 | sort -u
clojure
maven
neo4j
```

After:

```console
$ comm -12 <(bashbrew children debian | sort) <(bashbrew children ubuntu | sort) | cut -d: -f1 | sort -u
clojure
maven
neo4j
```