### PR TITLE
Add windows servers to smoke test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,9 +11,12 @@ defaults:
     shell: 'bash -Eeuo pipefail -x {0}'
 
 jobs:
-  build:
-    name: Build
-    runs-on: ubuntu-latest
+  build-matrix:
+    strategy:
+      matrix:
+        os: [ ubuntu-latest, windows-2019, windows-2022 ]
+    name: Build ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
       - uses: ./ # test our "action.yml" 👀
@@ -25,7 +28,7 @@ jobs:
           bashbrew cat "$image"
           bashbrew from --uniq "$image"
 
-          "$BASHBREW_SCRIPTS/bashbrew-host-arch.sh" # should print "amd64"
+          "$BASHBREW_SCRIPTS/bashbrew-host-arch.sh" # should print "amd64" or "windows-amd64"
 
           arm32v7="$("$BASHBREW_SCRIPTS/bashbrew-arch-to-goenv.sh" arm32v7)"
           eval "$arm32v7"

--- a/bashbrew.sh
+++ b/bashbrew.sh
@@ -6,7 +6,8 @@ set -Eeuo pipefail
 dir="$(readlink -f "$BASH_SOURCE")"
 dir="$(dirname "$dir")"
 
-export GO111MODULE=on
+: "${CGO_ENABLED:=0}"
+export GO111MODULE=on CGO_ENABLED
 (
 	cd "$dir"
 	go build -o bin/bashbrew ./cmd/bashbrew > /dev/null


### PR DESCRIPTION
Disable cgo to fix build failure on GHA `windows-2022`

Example failure from PRs to official-images:
```console
go: downloading github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da
# github.com/docker-library/bashbrew/cmd/bashbrew
C:\hostedtoolcache\windows\go\1.18.10\x64\pkg\tool\windows_amd64\link.exe: running gcc failed: exit status 1
C:/ProgramData/Chocolatey/lib/mingw/tools/install/mingw64/bin/../lib/gcc/x86_64-w64-mingw32/12.2.0/../../../../x86_64-w64-mingw32/bin/ld.exe: C:\Users\RUNNER~1\AppData\Local\Temp\go-link-3224421645\000008.o: in function `_cgo_preinit_init':
\\_\_\runtime\cgo/gcc_libinit_windows.c:30: undefined reference to `__imp___iob_func'
C:/ProgramData/Chocolatey/lib/mingw/tools/install/mingw64/bin/../lib/gcc/x86_64-w64-mingw32/12.2.0/../../../../x86_64-w64-mingw32/bin/ld.exe: C:\Users\RUNNER~1\AppData\Local\Temp\go-link-3224421645\000008.o: in function `x_cgo_sys_thread_create':
\\_\_\runtime\cgo/gcc_libinit_windows.c:60: undefined reference to `__imp___iob_func'
C:/ProgramData/Chocolatey/lib/mingw/tools/install/mingw64/bin/../lib/gcc/x86_64-w64-mingw32/12.2.0/../../../../x86_64-w64-mingw32/bin/ld.exe: C:\Users\RUNNER~1\AppData\Local\Temp\go-link-3224421645\000008.o: in function `x_cgo_notify_runtime_init_done':
\\_\_\runtime\cgo/gcc_libinit_windows.c:101: undefined reference to `__imp___iob_func'
C:/ProgramData/Chocolatey/lib/mingw/tools/install/mingw64/bin/../lib/gcc/x86_64-w64-mingw32/12.2.0/../../../../x86_64-w64-mingw32/bin/ld.exe: C:\Users\RUNNER~1\AppData\Local\Temp\go-link-3224421645\000009.o: in function `x_cgo_thread_start':
\\_\_\runtime\cgo/gcc_util.c:18: undefined reference to `__imp___iob_func'
C:/ProgramData/Chocolatey/lib/mingw/tools/install/mingw64/bin/../lib/gcc/x86_64-w64-mingw32/12.2.0/../../../../x86_64-w64-mingw32/bin/ld.exe: C:\Users\RUNNER~1\AppData\Local\Temp\go-link-3224421645\000010.o: in function `_cgo_sys_thread_start':
\\_\_\runtime\cgo/gcc_windows_amd64.c:31: undefined reference to `__imp___iob_func'
collect2.exe: error: ld returned 1 exit status
```











