### PR TITLE
Add the ability to use a jq module for custom functions in jq-template

### DIFF
--- a/scripts/jq-template.awk
+++ b/scripts/jq-template.awk
@@ -118,7 +118,16 @@ END {
 	append_jq(agg_jq)
 	agg_jq = ""
 
-	jq_expr = "if env.version then .[env.version] else . end | (\n" jq_expr "\n)"
+	# Test that the shared jq module exists before loading it
+	# This prevents breaking existing build that don't use the shared module
+	test = "jq -n 'include \"jq-template\"; \"ok\"' 2>&1 > /dev/null"
+
+	if (system (test) != 0) {
+		jq_expr = "if env.version then .[env.version] else . end | (\n" jq_expr "\n)"
+	} else {
+		jq_expr = "include \"jq-template\"; if env.version then .[env.version] else . end | (\n" jq_expr "\n)"
+	}
+
 	jq_expr = jq_expr_defs jq_expr
 
 	if (ENVIRON["DEBUG"]) {


### PR DESCRIPTION
This works by creating a `./jq-template.jq` at the same level as the jq-template.awk. A standard jq-template.jq can then be pulled which contain shared function or templates to use across DOI

If checks at the same location as the awk file for a jq module called jq-template.jq. If the modules it loads it to extend the templating function with custom jq functions and filters