### PR TITLE
Added shared module for jq template with SBOM generator

### DIFF
--- a/scripts/template-helper-functions.jq
+++ b/scripts/template-helper-functions.jq
@@ -1,0 +1,36 @@
+#input package 
+# {
+#     name: "packageName",
+#     version: "packageVersion",
+#     params: {
+#         "foo": "bar"
+#     }
+#     licenses: ["packageLicense" ... ]
+# }
+#output: object
+def sbom:
+    {
+		spdxVersion: "SPDX-2.3",
+		SPDXID: "SPDXRef-DOCUMENT",
+		name: (.name + "-sbom"),
+		packages: [
+			{
+				name: .name,
+				versionInfo: .version,
+				SPDXID: ("SPDXRef-Package--" + .name),
+				externalRefs: [
+					{
+						referenceCategory: "PACKAGE-MANAGER",
+						referenceType: "purl",
+						referenceLocator: ("pkg:generic/" + .name + "@" + .version + "?" + (.params | [to_entries[] | .key + "=" + .value] | join("\u0026")))
+					}
+				],
+				licenseDeclared: (if .licenses | length > 0 then
+					(.licenses | join(" AND "))
+				else
+					"NOASSERTION"
+				end)
+			}
+		]
+	}
+;


### PR DESCRIPTION
Input

```
{
    name: "erlang",
    version: "25.3.2.6"
    params: {
        os_name: "alpine",
        os_version: "3.17"
    },
    licenses: [
        "Apache-2.0",
        "MPL-2.0"
    ]
} | sbom | tostring
```

Output:

```json
{
    "spdxVersion": "SPDX-2.3",
    "SPDXID": "SPDXRef-DOCUMENT",
    "name": "erlang-sbom",
    "packages": [
        {
            "name": "erlang",
            "versionInfo": "25.3.2.6",
            "SPDXID": "SPDXRef-Package--erlang",
            "externalRefs": [
                {
                    "referenceCategory": "PACKAGE-MANAGER",
                    "referenceType": "purl",
                    "referenceLocator": "pkg:generic/erlang@25.3.2.6?os_name=alpine&os_version=3.18"
                }
            ],
            "licenseDeclared": "Apache-2.0 AND MPL-2.0"
        }
    ]
}
```