### PR TITLE
Add support for package supplier in SBOM

### DIFF
--- a/scripts/template-helper-functions.jq
+++ b/scripts/template-helper-functions.jq
@@ -25,12 +25,9 @@ def sbom:
 						referenceLocator: ("pkg:generic/" + .name + "@" + .version + "?" + (.params | [to_entries[] | .key + "=" + .value] | join("\u0026")))
 					}
 				],
-				licenseDeclared: (if .licenses | length > 0 then
-					(.licenses | join(" AND "))
-				else
-					"NOASSERTION"
-				end)
 			}
+			+ if .licenses then { licenseDeclared: (.licenses | join(" AND ")) } else {} end
+			+ if .supplier then { supplier: .supplier } else {} end
 		]
 	}
 ;


### PR DESCRIPTION
The purpose of this field is to help differentiate when a software can have the same name as another. Best example of this is Compose. There are many Compose so being able to specify that it's the Docker package named compose.

Example

```json
{
    "name": "compose",
    "versionInfo": "v2.23.0-desktop.1",
    "supplier": "Docker Inc.",
    ...
}
```