### PR TITLE
Let bashbrew pass arguments from environment variable to buildx

### DIFF
--- a/cmd/bashbrew/docker.go
+++ b/cmd/bashbrew/docker.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/docker-library/bashbrew/manifest"
 	"github.com/urfave/cli"
+	"github.com/kballard/go-shellquote"
 )
 
 type dockerfileMetadata struct {
@@ -295,6 +296,7 @@ const (
 	dockerfileSyntaxEnv = "BASHBREW_BUILDKIT_SYNTAX"
 	sbomGeneratorEnv    = "BASHBREW_BUILDKIT_SBOM_GENERATOR"
 	buildxBuilderEnv    = "BUILDX_BUILDER"
+	buildxArgsEnv       = "BUILDX_ARGS"
 )
 
 func dockerBuildxBuild(tags []string, file string, context io.Reader, platform string) error {
@@ -308,6 +310,13 @@ func dockerBuildxBuild(tags []string, file string, context io.Reader, platform s
 		"build",
 		"--progress", "plain",
 		"--build-arg", "BUILDKIT_SYNTAX=" + dockerfileSyntax,
+	}
+	buildxArgs, err := shellquote.Split(os.Getenv(buildxArgsEnv))
+	if err != nil {
+			return fmt.Errorf("%s in buildx arguments: %s.", err, os.Getenv(buildxArgsEnv))
+	}
+	if len(buildxArgs) > 0 {
+		args = append(args, buildxArgs...)
 	}
 	buildxBuilder := "" != os.Getenv(buildxBuilderEnv)
 	if buildxBuilder {

--- a/go.mod
+++ b/go.mod
@@ -36,6 +36,7 @@ require (
 	github.com/google/uuid v1.3.0 // indirect
 	github.com/imdario/mergo v0.3.13 // indirect
 	github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 // indirect
+	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 // indirect
 	github.com/kevinburke/ssh_config v1.2.0 // indirect
 	github.com/klauspost/compress v1.15.13 // indirect
 	github.com/moby/locker v1.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -455,6 +455,8 @@ github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
+github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 h1:Z9n2FFNUXsshfwJMBgNA0RU6/i7WVaAegv3PtuIHPMs=
+github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51/go.mod h1:CzGEWj7cYgsdH8dAjBGEr58BoE7ScuLd+fwFZ44+/x8=
 github.com/kevinburke/ssh_config v1.2.0 h1:x584FjTGwHzMwvHx18PXxbBVzfnxogHaAReU4gf13a4=
 github.com/kevinburke/ssh_config v1.2.0/go.mod h1:CT57kijsi8u/K/BOFA39wgDQJ9CxiF4nAY/ojJ6r6mM=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=


### PR DESCRIPTION
Hello,

I tried using bashbrew for maintaining my local library but it occurred that I can't pass secrets into Dockerfiles with it. Or I failed to find how to pass secrets with bashbrew.

The patch introduces a way of passing `buildx build` arguments through BUILDX_ARGS environment variable.  
While I only needed secrets, I believe, it makes sense to introduce a slightly more generic mechanism.

There is a simple check for sanity using https://github.com/kballard/go-shellquote . But it only makes sure that arguments are properly split into words before passing those to `buildx`. The check doesn't prevent a user from passing a wrong argument.

An example of usage would look like this:
```
BUILDX_ARGS="--secret id=cert,src=~/build.cert" bashbrew build --all
```
An argument list like below will cause an error message:
```
~: BUILDX_ARGS="--secret \"id=cert,src=~/build.cert" bashbrew build --all
Unterminated double-quoted string in buildx arguments: --secret "id=cert,src=~/build.cert.
```
I'm not quoting error message because it is one of three pre-defined strings. And I'm not quoting the arguments list to ease identifying an issue.

I hope this makes sense.