### PR TITLE
Fix fetchRegistryImageIds (which is only used for "docker push" no-op) to no longer return members of an index/manifest list

### DIFF
--- a/cmd/bashbrew/registry.go
+++ b/cmd/bashbrew/registry.go
@@ -28,6 +28,12 @@ func fetchRegistryImageIds(image string) []string {
 		return ids
 	}
 
+	ids := []string{}
+	if img.IsImageIndex() {
+		ids = append(ids, digest)
+		return ids // see note above -- this function is used for "docker push" which does not and cannot (currently) support a manifest list / image index
+	}
+
 	manifests, err := img.Manifests(ctx)
 	if err != nil {
 		if debugFlag {
@@ -36,10 +42,8 @@ func fetchRegistryImageIds(image string) []string {
 		return nil
 	}
 
-	ids := []string{}
-	if img.IsImageIndex() {
-		ids = append(ids, digest)
-	}
+	// TODO balk if manifests has more than one entry in it
+
 	for _, manifestDesc := range manifests {
 		ids = append(ids, manifestDesc.Digest.String())
 		manifest, err := img.At(manifestDesc).Manifest(ctx)


### PR DESCRIPTION
This isn't the _cause_ of https://github.com/docker-library/python/issues/888, but it sure is making it hard to fix (because the image that needs to be pushed to that tag is claiming to already be pushed since it's a member of the pushed image already even though it _should_ be pushed).