### PR TITLE
Add `sha256sum` template function

### DIFF
--- a/pkg/templatelib/lib.go
+++ b/pkg/templatelib/lib.go
@@ -1,6 +1,8 @@
 package templatelib
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -135,4 +137,10 @@ var FuncMap = template.FuncMap{
 			return unsetVal
 		}
 	}),
+
+	// {{- sha256sum "hello world" -}}
+	"sha256sum": func(input string) string {
+		hash := sha256.Sum256([]byte(input))
+		return hex.EncodeToString(hash[:])
+	},
 }


### PR DESCRIPTION
This is intentionally named and implemented to match the one in Sprig: https://masterminds.github.io/sprig/crypto.html

I need this so that https://github.com/docker-library/meta-scripts/pull/16 can calculate `sourceId`s in pure `bashbrew` formatting (and thus be really fast): :sweat_smile:

```
...
	{{- $sum := $.ArchGitChecksum $a . -}}
	{{- $file := .ArchFile $a -}}
	{{- $builder := .ArchBuilder $a -}}
	{
		"sourceId": {{ join "\n" $sum $file $builder "" | sha256sum | json }},
		"reproducibleGitChecksum": {{ $sum | json }},
...
```