### PR TITLE
Fix `ArchLastStageFrom` with `oci-import` builder

### DIFF
--- a/cmd/bashbrew/docker.go
+++ b/cmd/bashbrew/docker.go
@@ -55,6 +55,9 @@ var dockerfileMetadataCache = map[string]*dockerfileMetadata{}
 func (r Repo) archDockerfileMetadata(arch string, entry *manifest.Manifest2822Entry) (*dockerfileMetadata, error) {
 	if builder := entry.ArchBuilder(arch); builder == "oci-import" {
 		return &dockerfileMetadata{
+			StageFroms: []string{
+				"scratch",
+			},
 			Froms: []string{
 				"scratch",
 			},


### PR DESCRIPTION
Before:

```console
$ bashbrew cat --format '{{ .ArchLastStageFrom arch .TagEntry }}' ubuntu:latest
failed executing template for repo "ubuntu:latest"
template: --format:1:3: executing "--format" at <.ArchLastStageFrom>: error calling ArchLastStageFrom: runtime error: index out of range [-1]
```

After:

```console
$ bashbrew cat --format '{{ .ArchLastStageFrom arch .TagEntry }}' ubuntu:latest
scratch
```