### PR TITLE
actions: bump setup-go to v5

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -8,7 +8,7 @@ description: 'Install the "bashbrew" tool in GITHUB_PATH'
 runs:
   using: 'composite'
   steps:
-    - uses: actions/setup-go@v3
+    - uses: actions/setup-go@v5
       with:
         go-version-file: '${{ github.action_path }}/go.mod'
     - run: |


### PR DESCRIPTION
Removes the warnings about Node.js 16 actions being deprecated