### PR TITLE
Fetch only necessary commits for build

### DIFF
--- a/cmd/bashbrew/git.go
+++ b/cmd/bashbrew/git.go
@@ -280,6 +280,7 @@ func (r Repo) fetchGitRepo(arch string, entry *manifest.Manifest2822Entry) (stri
 		err := gitRemote.Fetch(&goGit.FetchOptions{
 			RefSpecs: []goGitConfig.RefSpec{goGitConfig.RefSpec(fetchString)},
 			Tags:     goGit.NoTags,
+			Depth:    1,
 
 			//Progress: os.Stdout,
 		})


### PR DESCRIPTION
In https://github.com/docker-library/official-images/pull/15846 @LaurentGoderre asked me to move the Dockerfiles into an orphan branch because bashbrew spends a huge time to fetch the git references.

Here's the simplest change improves the fetch by an order of magnitude:

```
$ time (rm -rf ~/.cache/bashbrew && ~/Space/go/bin/bashbrew --debug build library/clickhouse)
Using bashbrew/cache:e3168289a003ed8aa644f472b1d6a4521683d5c1a6a12765f9a0329d375dd4d1 (clickhouse:latest)
$ export DOCKER_BUILDKIT=0
$ docker ["build" "--tag" "clickhouse:latest" "--tag" "clickhouse:focal" "--tag" "clickhouse:24" "--tag" "clickhouse:24-focal" "--tag" "clickhouse:24.4" "--tag" "clickhouse:24.4-focal" "--tag" "clickhouse:24.4.1" "--tag" "clickhouse:24.4.1-focal" "--tag" "clickhouse:24.4.1.2088" "--tag" "clickhouse:24.4.1.2088-focal" "--rm" "--force-rm" "-"]
DEPRECATED: The legacy builder is deprecated and will be removed in a future release.
            BuildKit is currently disabled; enable it by removing the DOCKER_BUILDKIT=0
            environment-variable.

Sending build context to Docker daemon  2.048kB
Step 1/1 : FROM bashbrew/cache:e3168289a003ed8aa644f472b1d6a4521683d5c1a6a12765f9a0329d375dd4d1
 ---> e6a434d83fd8
Successfully built e6a434d83fd8
Successfully tagged clickhouse:latest
Successfully tagged clickhouse:focal
Successfully tagged clickhouse:24
Successfully tagged clickhouse:24-focal
Successfully tagged clickhouse:24.4
Successfully tagged clickhouse:24.4-focal
Successfully tagged clickhouse:24.4.1
Successfully tagged clickhouse:24.4.1-focal
Successfully tagged clickhouse:24.4.1.2088
Successfully tagged clickhouse:24.4.1.2088-focal
( rm -rf ~/.cache/bashbrew && ~/Space/go/bin/bashbrew --debug build ; )  4,64s user 0,78s system 34% cpu 15,659 total
$ time (rm -rf ~/.cache/bashbrew && bashbrew --debug build library/clickhouse)
Using bashbrew/cache:e3168289a003ed8aa644f472b1d6a4521683d5c1a6a12765f9a0329d375dd4d1 (clickhouse:latest)
$ export DOCKER_BUILDKIT=0
$ docker ["build" "--tag" "clickhouse:latest" "--tag" "clickhouse:focal" "--tag" "clickhouse:24" "--tag" "clickhouse:24-focal" "--tag" "clickhouse:24.4" "--tag" "clickhouse:24.4-focal" "--tag" "clickhouse:24.4.1" "--tag" "clickhouse:24.4.1-focal" "--tag" "clickhouse:24.4.1.2088" "--tag" "clickhouse:24.4.1.2088-focal" "--rm" "--force-rm" "-"]
DEPRECATED: The legacy builder is deprecated and will be removed in a future release.
            BuildKit is currently disabled; enable it by removing the DOCKER_BUILDKIT=0
            environment-variable.

Sending build context to Docker daemon  2.048kB
Step 1/1 : FROM bashbrew/cache:e3168289a003ed8aa644f472b1d6a4521683d5c1a6a12765f9a0329d375dd4d1
 ---> e6a434d83fd8
Successfully built e6a434d83fd8
Successfully tagged clickhouse:latest
Successfully tagged clickhouse:focal
Successfully tagged clickhouse:24
Successfully tagged clickhouse:24-focal
Successfully tagged clickhouse:24.4
Successfully tagged clickhouse:24.4-focal
Successfully tagged clickhouse:24.4.1
Successfully tagged clickhouse:24.4.1-focal
Successfully tagged clickhouse:24.4.1.2088
Successfully tagged clickhouse:24.4.1.2088-focal
( rm -rf ~/.cache/bashbrew && bashbrew --debug build library/clickhouse; )  255,70s user 15,34s system 113% cpu 3:59,07 total
$ bashbrew --version
bashbrew version v0.1.13
$ ~/Space/go/bin/bashbrew --version
bashbrew version v0.1.13
```