### PR TITLE
Add explicit `cache-dependency-path` to `action.yml`

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -11,6 +11,7 @@ runs:
     - uses: actions/setup-go@v5
       with:
         go-version-file: '${{ github.action_path }}/go.mod'
+        cache-dependency-path: '${{ github.action_path }}/go.sum'
     - run: |
         '${{ github.action_path }}/bashbrew.sh' --version > /dev/null
         '${{ github.action_path }}/bin/bashbrew' --version


### PR DESCRIPTION
This *should* squash the `Warning: Restore cache failed: Dependencies file is not found in /home/runner/work/xxx/yyy. Supported file pattern: go.sum` note we've been getting on all our builds. 🙃