### PR TITLE
Disable Codecov (for now)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,12 +42,13 @@ jobs:
         run: |
           docker build --pull --file Dockerfile.test --tag test .
           docker run --rm test cat coverage.out > coverage.out
-      - name: Codecov
-        uses: codecov/codecov-action@v3
-        with:
-          files: coverage.out
-          fail_ci_if_error: true
-          verbose: true
+      # TODO find a suitable codecov solution that doesn't require privileged access to the org/repo
+      #- name: Codecov
+      #  uses: codecov/codecov-action@v3
+      #  with:
+      #    files: coverage.out
+      #    fail_ci_if_error: true
+      #    verbose: true
   dockerfile:
     name: Test Dockerfile
     runs-on: ubuntu-latest


### PR DESCRIPTION
It's been failing to upload for a while, and I don't think the failures are *completely* their fault (GitHub's got to share some of the blame, I think), but the end result is that we don't really have any good options for continuing to use the service (bad/unacceptable options include install an app with way too many privileges on the org/repo or add a "secret" with a personal access token ... and make that available to Pull Requests too 🙃).