### PR TITLE
Enforce that `GitCommit` must be a *full* commit hash

### DIFF
--- a/manifest/rfc2822.go
+++ b/manifest/rfc2822.go
@@ -16,7 +16,7 @@ import (
 )
 
 var (
-	GitCommitRegex = regexp.MustCompile(`^[0-9a-f]{1,64}$`)
+	GitCommitRegex = regexp.MustCompile(`^([0-9a-f]{40}|[0-9a-f]{64})$`)
 	GitFetchRegex  = regexp.MustCompile(`^refs/(heads|tags)/[^*?:]+$`)
 
 	// https://github.com/docker/distribution/blob/v2.7.1/reference/regexp.go#L37


### PR DESCRIPTION
I thought this was already the behavior, but I guess it was relaxed because previous iterations of this validation had to apply to the older format where we'd been less meticulous about enforcing this.  Since those are all gone now, we can safely update the validation to enforce that commit hashes *must* be fully qualified.