### PR TITLE
Add support for linux/loong64

### DIFF
--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -21,6 +21,7 @@ ENV BASHBREW_ARCHES \
 		arm64v8 \
 		darwin-amd64 \
 		i386 \
+		loong64 \
 		mips64le \
 		ppc64le \
 		riscv64 \
@@ -41,7 +42,9 @@ RUN export GNUPGHOME="$(mktemp -d)"; \
 	\
 	for bashbrewArch in $BASHBREW_ARCHES; do \
 # TODO convince estesp to release riscv64 binaries (https://github.com/estesp/manifest-tool/pull/113 👀)
+# also https://github.com/estesp/manifest-tool/pull/274 for loong64 support
 		if [ "$bashbrewArch" = 'riscv64' ]; then continue; fi; \
+		if [ "$bashbrewArch" = 'loong64' ]; then continue; fi; \
 		( \
 			goEnv="$(bashbrew-arch-to-goenv.sh "$bashbrewArch")"; eval "$goEnv"; \
 			srcBin="manifest-tool-$GOOS-$GOARCH"; \

--- a/architecture/oci-platform.go
+++ b/architecture/oci-platform.go
@@ -18,6 +18,7 @@ var SupportedArches = map[string]OCIPlatform{
 	"arm32v7":  {OS: "linux", Architecture: "arm", Variant: "v7"},
 	"arm64v8":  {OS: "linux", Architecture: "arm64", Variant: "v8"},
 	"i386":     {OS: "linux", Architecture: "386"},
+	"loong64":  {OS: "linux", Architecture: "loong64"},
 	"mips64le": {OS: "linux", Architecture: "mips64le"},
 	"ppc64le":  {OS: "linux", Architecture: "ppc64le"},
 	"riscv64":  {OS: "linux", Architecture: "riscv64"},

--- a/scripts/bashbrew-host-arch.sh
+++ b/scripts/bashbrew-host-arch.sh
@@ -27,16 +27,17 @@ elif command -v uname > /dev/null && tryArch="$(uname -m)"; then
 fi
 
 case "$arch" in
-	amd64 | x86_64)    found 'amd64'    ;;
-	arm64 | aarch64)   found 'arm64v8'  ;;
-	armel)             found 'arm32v5'  ;;
-	armv6*)            found 'arm32v6'  ;;
-	armv7*)            found 'arm32v7'  ;;
-	i[3456]86 | x86)   found 'i386'     ;;
-	mips64el)          found 'mips64le' ;; # TODO "uname -m" is just "mips64" (which is also "apk --print-arch" on big-endian MIPS) so we ought to disambiguate that somehow
-	ppc64el | ppc64le) found 'ppc64le'  ;;
-	riscv64)           found 'riscv64'  ;;
-	s390x)             found 's390x'    ;;
+	amd64 | x86_64)        found 'amd64'    ;;
+	arm64 | aarch64)       found 'arm64v8'  ;;
+	armel)                 found 'arm32v5'  ;;
+	armv6*)                found 'arm32v6'  ;;
+	armv7*)                found 'arm32v7'  ;;
+	i[3456]86 | x86)       found 'i386'     ;;
+	loong64 | loongarch64) found 'loong64'  ;;
+	mips64el)              found 'mips64le' ;; # TODO "uname -m" is just "mips64" (which is also "apk --print-arch" on big-endian MIPS) so we ought to disambiguate that somehow
+	ppc64el | ppc64le)     found 'ppc64le'  ;;
+	riscv64)               found 'riscv64'  ;;
+	s390x)                 found 's390x'    ;;
 
 	armhf)
 		if [ -s /etc/os-release ] && id="$(grep -Em1 '^ID=[^[:space:]]+$' /etc/os-release)"; then


### PR DESCRIPTION
Note: while I see ["compliance requirements"](https://github.com/docker-library/official-images/issues/16404#issuecomment-2173733639) :eyes: in the postponed-for-now Docker Official Image inclusion request by a Loongson employee, I'm personally not affiliated with Loongson, and I'm not sure if that means this change is also affected. The changes themselves are trivial though.