### PR TITLE
Update `bashbrew-arch-to-goenv.sh` with more edge cases

### DIFF
--- a/scripts/bashbrew-arch-to-goenv.sh
+++ b/scripts/bashbrew-arch-to-goenv.sh
@@ -1,5 +1,5 @@
-#!/bin/sh
-set -eu
+#!/usr/bin/env bash
+set -Eeuo pipefail
 
 # usage: (from within another script)
 #   shell="$(./bashbrew-arch-to-goenv.sh arm32v6)"
@@ -10,33 +10,65 @@ bashbrewArch="$1"; shift # "amd64", "arm32v5", "windows-amd64", etc.
 
 os="${bashbrewArch%%-*}"
 [ "$os" != "$bashbrewArch" ] || os='linux'
-printf 'export GOOS="%s"\n' "$os"
-
 arch="${bashbrewArch#${os}-}"
+
+declare -A envs=(
+	# https://pkg.go.dev/cmd/go#hdr-Build_constraints
+	# https://gist.github.com/asukakenji/f15ba7e588ac42795f421b48b8aede63
+
+	[GOOS]="$os"
+	[GOARCH]="$arch"
+
+	# https://go.dev/wiki/MinimumRequirements#architectures
+	[GO386]=
+	[GOAMD64]=
+	[GOARM64]=
+	[GOARM]=
+	[GOMIPS64]=
+	[GOPPC64]=
+	[GORISCV64]=
+)
+
 case "$arch" in
+	amd64)
+		envs[GOAMD64]='v1'
+		;;
+
 	arm32v*)
-		printf 'export GOARCH="%s"\n' 'arm'
-		printf 'export GOARM="%s"\n' "${arch#arm32v}"
+		envs[GOARCH]='arm'
+		envs[GOARM]="${arch#arm32v}" # "6", "7", "8", etc
 		;;
 
 	arm64v*)
-		printf 'export GOARCH="%s"\n' 'arm64'
-		# no GOARM(64) for arm64 (yet?):
-		#   https://github.com/golang/go/blob/be0e0b06ac53d3d02ea83b479790404057b6f19b/src/internal/buildcfg/cfg.go#L86
-		#   https://github.com/golang/go/issues/60905
-		#printf 'export GOARM64="v%s"\n' "${arch#arm64v}"
-		printf 'unset GOARM\n'
+		envs[GOARCH]='arm64'
+		version="${arch#arm64v}"
+		if [ -z "${version%%[0-9]}" ]; then
+			# if the version is just a raw number ("8", "9"), we should append ".0"
+			# https://go-review.googlesource.com/c/go/+/559555/comment/e2049987_1bc3a065/
+			# (Go has "v8.0" but no bare "v8")
+			version+='.0'
+		fi
+		envs[GOARM64]="v$version" # "v8.0", "v9.0", etc
 		;;
 
 	i386)
-		printf 'export GOARCH="%s"\n' '386'
-		printf 'unset GOARM\n'
+		envs[GOARCH]='386'
 		;;
 
-	# TODO GOAMD64: https://github.com/golang/go/blob/be0e0b06ac53d3d02ea83b479790404057b6f19b/src/internal/buildcfg/cfg.go#L57-L70 (v1 implied)
-
-	*)
-		printf 'export GOARCH="%s"\n' "$arch"
-		printf 'unset GOARM\n'
-		;;
+	# TODO GOMIPS64?
+	# TODO GOPPC64?
+	# TODO GORISCV64?
 esac
+
+exports=
+unsets=
+for key in "${!envs[@]}"; do
+	val="${envs[$key]}"
+	if [ -n "$val" ]; then
+		exports+=" $(printf '%s=%q' "$key" "$val")"
+	else
+		unsets+=" $key"
+	fi
+done
+[ -z "$exports" ] || printf 'export%s\n' "$exports"
+[ -z "$unsets" ] || printf 'unset%s\n' "$unsets"


### PR DESCRIPTION
Also, Go updates (`GOAMD64`, `GOARM64`, etc)

```console
$ for bashbrewArch in $(grep -oE '^[[:space:]]+"[^[:space:]]+":' architecture/oci-platform.go | cut -d'"' -f2); do echo "# $bashbrewArch"; ./scripts/bashbrew-arch-to-goenv.sh "$bashbrewArch"; echo; done
# amd64
export GOARCH=amd64 GOAMD64=v1 GOOS=linux
unset GO386 GOARM GOMIPS64 GOARM64 GORISCV64 GOPPC64

# arm32v5
export GOARCH=arm GOARM=5 GOOS=linux
unset GO386 GOMIPS64 GOARM64 GORISCV64 GOAMD64 GOPPC64

# arm32v6
export GOARCH=arm GOARM=6 GOOS=linux
unset GO386 GOMIPS64 GOARM64 GORISCV64 GOAMD64 GOPPC64

# arm32v7
export GOARCH=arm GOARM=7 GOOS=linux
unset GO386 GOMIPS64 GOARM64 GORISCV64 GOAMD64 GOPPC64

# arm64v8
export GOARCH=arm64 GOARM64=v8.0 GOOS=linux
unset GO386 GOARM GOMIPS64 GORISCV64 GOAMD64 GOPPC64

# i386
export GOARCH=386 GOOS=linux
unset GO386 GOARM GOMIPS64 GOARM64 GORISCV64 GOAMD64 GOPPC64

# mips64le
export GOARCH=mips64le GOOS=linux
unset GO386 GOARM GOMIPS64 GOARM64 GORISCV64 GOAMD64 GOPPC64

# ppc64le
export GOARCH=ppc64le GOOS=linux
unset GO386 GOARM GOMIPS64 GOARM64 GORISCV64 GOAMD64 GOPPC64

# riscv64
export GOARCH=riscv64 GOOS=linux
unset GO386 GOARM GOMIPS64 GOARM64 GORISCV64 GOAMD64 GOPPC64

# s390x
export GOARCH=s390x GOOS=linux
unset GO386 GOARM GOMIPS64 GOARM64 GORISCV64 GOAMD64 GOPPC64

# windows-amd64
export GOARCH=amd64 GOAMD64=v1 GOOS=windows
unset GO386 GOARM GOMIPS64 GOARM64 GORISCV64 GOPPC64
```