### PR TITLE
Rename "Example" tests to satisfy Go 1.24's new vet rule

### DIFF
--- a/pkg/gitfs/tarscrub_test.go
+++ b/pkg/gitfs/tarscrub_test.go
@@ -14,7 +14,7 @@ import (
 
 // this example is nice because it has some intentionally dangling symlinks in it that trip things up if they aren't implemented correctly!
 // (see also pkg/tarscrub/git_test.go)
-func ExampleGitVarnish() {
+func Example_gitVarnish() {
 	repo, err := git.Clone(memory.NewStorage(), nil, &git.CloneOptions{
 		URL:          "https://github.com/varnish/docker-varnish.git",
 		SingleBranch: true,
@@ -46,7 +46,7 @@ func ExampleGitVarnish() {
 // this example is nice because it has a different committer vs author timestamp
 // https://github.com/tianon/docker-bash/commit/eb7e541caccc813d297e77cf4068f89553256673
 // https://github.com/docker-library/official-images/blob/8718b8afb62ff1a001d99bb4f77d95fe352ba187/library/bash
-func ExampleGitBash() {
+func Example_gitBash() {
 	repo, err := git.Clone(memory.NewStorage(), nil, &git.CloneOptions{
 		URL:          "https://github.com/tianon/docker-bash.git",
 		SingleBranch: true,

--- a/pkg/tarscrub/git_test.go
+++ b/pkg/tarscrub/git_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/go-git/go-git/v5/storage/memory"
 )
 
-func ExampleGitHello() {
+func Example_gitHello() {
 	repo, err := git.Clone(memory.NewStorage(), nil, &git.CloneOptions{
 		URL:          "https://github.com/docker-library/hello-world.git",
 		SingleBranch: true,
@@ -43,7 +43,7 @@ func ExampleGitHello() {
 
 // this example is nice because it has some intentionally dangling symlinks in it that trip things up if they aren't implemented correctly!
 // (see also pkg/gitfs/tarscrub_test.go)
-func ExampleGitVarnish() {
+func Example_gitVarnish() {
 	repo, err := git.Clone(memory.NewStorage(), nil, &git.CloneOptions{
 		URL:          "https://github.com/varnish/docker-varnish.git",
 		SingleBranch: true,


### PR DESCRIPTION
In Go 1.24, there's a new `go vet` rule that complains about `Example*` test functions that don't follow the documented naming convention.  Combine that with `go test` running `go vet` by default, and you've got a perfect storm.

This renames our "example" tests to satisfy Go's naming convention.

Closes https://github.com/docker-library/bashbrew/issues/116