### PR TITLE
Remove `go mod verify`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ SHELL ["bash", "-Eeuo", "pipefail", "-xc"]
 WORKDIR /usr/src/bashbrew
 
 COPY go.mod go.sum ./
-RUN go mod download; go mod verify
+RUN go mod download
 
 COPY . .
 

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -64,7 +64,7 @@ RUN export GNUPGHOME="$(mktemp -d)"; \
 	file bin/manifest-tool-*
 
 COPY go.mod go.sum ./
-RUN go mod download; go mod verify
+RUN go mod download
 
 COPY . .
 

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -5,7 +5,7 @@ SHELL ["bash", "-Eeuo", "pipefail", "-xc"]
 WORKDIR /usr/src/bashbrew
 
 COPY go.mod go.sum ./
-RUN go mod download; go mod verify
+RUN go mod download
 
 COPY . .
 


### PR DESCRIPTION
(it verifies that the downloaded modules have not been tampered with since `go mod download`, which we do literally just prior so it is verifying nothing)