### PR TITLE
Remove "windows-2019" support from GHA scripts

### DIFF
--- a/scripts/github-actions/generate.sh
+++ b/scripts/github-actions/generate.sh
@@ -65,8 +65,6 @@ for tag in $tags; do
 						"windows-2025"
 					elif (.constraints | contains(["windowsservercore-ltsc2022"])) or (.constraints | contains(["nanoserver-ltsc2022"])) then
 						"windows-2022"
-					elif (.constraints | contains(["windowsservercore-1809"])) or (.constraints | contains(["nanoserver-1809"])) then
-						"windows-2019"
 					elif .constraints == [] or .constraints == ["!aufs"] then
 						"ubuntu-latest"
 					else


### PR DESCRIPTION
See:
- https://github.com/docker-library/official-images/pull/19138
- https://github.com/docker-library/official-images/issues/18910
- https://github.blog/changelog/2025-04-15-upcoming-breaking-changes-and-releases-for-github-actions/#windows-server-2019-is-closing-down