### PR TITLE
Access private Git repositories using HTTP Basic authentication

### DIFF
--- a/cmd/bashbrew/cmd-build.go
+++ b/cmd/bashbrew/cmd-build.go
@@ -89,7 +89,7 @@ func cmdBuild(c *cli.Context) error {
 			if err != nil {
 				fmt.Printf("Building %s (%s)\n", cacheTag, r.EntryIdentifier(entry))
 				if !dryRun {
-					commit, err := r.fetchGitRepo(arch, entry)
+					commit, err := r.fetchGitRepo(arch, entry, auth)
 					if err != nil {
 						return cli.NewMultiError(fmt.Errorf(`failed fetching git repo for %q (tags %q)`, r.RepoName, entry.TagsString()), err)
 					}

--- a/cmd/bashbrew/cmd-fetch.go
+++ b/cmd/bashbrew/cmd-fetch.go
@@ -36,7 +36,7 @@ func cmdFetch(c *cli.Context) error {
 			}
 
 			for _, entryArch := range arches {
-				commit, err := r.fetchGitRepo(entryArch, entry)
+				commit, err := r.fetchGitRepo(entryArch, entry, auth)
 				if err != nil {
 					return cli.NewMultiError(fmt.Errorf(`failed fetching git repo for %q (tags %q on arch %q)`, r.RepoName, entry.TagsString(), entryArch), err)
 				}

--- a/cmd/bashbrew/docker.go
+++ b/cmd/bashbrew/docker.go
@@ -54,7 +54,7 @@ func (r Repo) archDockerfileMetadata(arch string, entry *manifest.Manifest2822En
 		return scratchDockerfileMetadata()
 	}
 
-	commit, err := r.fetchGitRepo(arch, entry)
+	commit, err := r.fetchGitRepo(arch, entry, auth)
 	if err != nil {
 		return dockerfile.Metadata{}, cli.NewMultiError(fmt.Errorf("failed fetching Git repo for arch %q from entry %q", arch, entry.String()), err)
 	}

--- a/cmd/bashbrew/git.go
+++ b/cmd/bashbrew/git.go
@@ -22,6 +22,8 @@ import (
 	goGit "github.com/go-git/go-git/v5"
 	goGitConfig "github.com/go-git/go-git/v5/config"
 	goGitPlumbing "github.com/go-git/go-git/v5/plumbing"
+
+	"github.com/go-git/go-git/v5/plumbing/transport/http"
 )
 
 func gitCache() string {
@@ -97,8 +99,8 @@ func getGitCommit(commit string) (string, error) {
 	return h.String(), nil
 }
 
-func (r Repo) archGitFS(arch string, entry *manifest.Manifest2822Entry) (fs.FS, error) {
-	commit, err := r.fetchGitRepo(arch, entry)
+func (r Repo) archGitFS(arch string, entry *manifest.Manifest2822Entry, auth http.AuthMethod) (fs.FS, error) {
+	commit, err := r.fetchGitRepo(arch, entry, auth)
 	if err != nil {
 		return nil, fmt.Errorf("failed fetching %q: %w", r.EntryIdentifier(entry), err)
 	}
@@ -112,8 +114,8 @@ func (r Repo) archGitFS(arch string, entry *manifest.Manifest2822Entry) (fs.FS, 
 }
 
 // returns the timestamp of the ArchGitCommit -- useful for SOURCE_DATE_EPOCH
-func (r Repo) ArchGitTime(arch string, entry *manifest.Manifest2822Entry) (time.Time, error) {
-	f, err := r.archGitFS(arch, entry)
+func (r Repo) ArchGitTime(arch string, entry *manifest.Manifest2822Entry, auth http.AuthMethod) (time.Time, error) {
+	f, err := r.archGitFS(arch, entry, auth)
 	if err != nil {
 		return time.Time{}, err
 	}
@@ -194,7 +196,7 @@ func gitNormalizeForTagUsage(text string) string {
 
 var gitRepoCache = map[string]string{}
 
-func (r Repo) fetchGitRepo(arch string, entry *manifest.Manifest2822Entry) (string, error) {
+func (r Repo) fetchGitRepo(arch string, entry *manifest.Manifest2822Entry, auth http.AuthMethod) (string, error) {
 	cacheKey := strings.Join([]string{
 		entry.ArchGitRepo(arch),
 		entry.ArchGitFetch(arch),
@@ -280,6 +282,7 @@ func (r Repo) fetchGitRepo(arch string, entry *manifest.Manifest2822Entry) (stri
 		err := gitRemote.Fetch(&goGit.FetchOptions{
 			RefSpecs: []goGitConfig.RefSpec{goGitConfig.RefSpec(fetchString)},
 			Tags:     goGit.NoTags,
+			Auth:     auth,
 
 			//Progress: os.Stdout,
 		})

--- a/cmd/bashbrew/main.go
+++ b/cmd/bashbrew/main.go
@@ -13,6 +13,8 @@ import (
 
 	"github.com/docker-library/bashbrew/architecture"
 	"github.com/docker-library/bashbrew/manifest"
+
+	"github.com/go-git/go-git/v5/plumbing/transport/http"
 )
 
 // TODO somewhere, ensure that the Docker engine we're talking to is API version 1.22+ (Docker 1.10+)
@@ -36,6 +38,10 @@ var (
 	debugFlag  = false
 	noSortFlag = false
 
+	gitUsername string
+	gitPassword string
+	auth        http.AuthMethod
+
 	// separated so that FlagsConfig.ApplyTo can access them
 	flagEnvVars = map[string]string{
 		"debug":     "BASHBREW_DEBUG",
@@ -48,6 +54,9 @@ var (
 
 		"constraint":     "BASHBREW_CONSTRAINTS",
 		"arch-namespace": "BASHBREW_ARCH_NAMESPACES",
+
+		"git-username": "BASHBREW_GIT_USERNAME",
+		"git-password": "BASHBREW_GIT_PASSWORD",
 	}
 )
 
@@ -138,6 +147,18 @@ func main() {
 			EnvVar: flagEnvVars["cache"],
 			Usage:  "where the git wizardry is stashed",
 		},
+		cli.StringFlag{
+			Name:   "git-username",
+			Value:  "",
+			EnvVar: flagEnvVars["git-username"],
+			Usage:  "access the git repository as this user",
+		},
+		cli.StringFlag{
+			Name:   "git-password",
+			Value:  "",
+			EnvVar: flagEnvVars["git-password"],
+			Usage:  "authenticate access to the Git repository with this password or token",
+		},
 	}
 
 	app.Before = func(c *cli.Context) error {
@@ -177,6 +198,15 @@ func main() {
 			namespace = c.GlobalString("namespace")
 			constraints = c.GlobalStringSlice("constraint")
 			exclusiveConstraints = c.GlobalBool("exclusive-constraints")
+			gitUsername = c.GlobalString("git-username")
+			gitPassword = c.GlobalString("git-password")
+
+			if gitUsername != "" && gitPassword != "" {
+				auth = &http.BasicAuth{
+					Username: gitUsername,
+					Password: gitPassword,
+				}
+			}
 
 			if arch == "" {
 				// weird edge case... ("BASHBREW_ARCH=")
@@ -462,7 +492,7 @@ func main() {
 				}
 
 				if c.Bool("sha256") {
-					sum, err := r.ArchGitChecksum(arch, r.TagEntry)
+					sum, err := r.ArchGitChecksum(arch, r.TagEntry, auth)
 					if err != nil {
 						return err
 					}
@@ -472,7 +502,7 @@ func main() {
 					if xTerm.IsTerminal(int(os.Stdout.Fd())) {
 						return fmt.Errorf("cowardly refusing to output a tar to a terminal")
 					}
-					return r.archContextTar(arch, r.TagEntry, os.Stdout)
+					return r.archContextTar(arch, r.TagEntry, auth, os.Stdout)
 				}
 			},
 

--- a/cmd/bashbrew/tar.go
+++ b/cmd/bashbrew/tar.go
@@ -7,10 +7,12 @@ import (
 
 	"github.com/docker-library/bashbrew/manifest"
 	"github.com/docker-library/bashbrew/pkg/tarscrub"
+
+	"github.com/go-git/go-git/v5/plumbing/transport/http"
 )
 
-func (r Repo) archContextTar(arch string, entry *manifest.Manifest2822Entry, w io.Writer) error {
-	f, err := r.archGitFS(arch, entry)
+func (r Repo) archContextTar(arch string, entry *manifest.Manifest2822Entry, auth http.AuthMethod, w io.Writer) error {
+	f, err := r.archGitFS(arch, entry, auth)
 	if err != nil {
 		return err
 	}
@@ -18,9 +20,9 @@ func (r Repo) archContextTar(arch string, entry *manifest.Manifest2822Entry, w i
 	return tarscrub.WriteTar(f, w)
 }
 
-func (r Repo) ArchGitChecksum(arch string, entry *manifest.Manifest2822Entry) (string, error) {
+func (r Repo) ArchGitChecksum(arch string, entry *manifest.Manifest2822Entry, auth http.AuthMethod) (string, error) {
 	h := sha256.New()
-	err := r.archContextTar(arch, entry, h)
+	err := r.archContextTar(arch, entry, auth, h)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
This was adapted from docker-library/bashbrew#41.

Unfortunately, work on go-git/go-git#490 and go-git/go-git#491 has been abandoned, so I would like to propose adding HTTP Basic authentication support back into bashbrew.  Compared to the original pull request, I corrected the imports, created missing environment variable mappings (`BASHBREW_GIT_USERNAME` and `BASHBREW_GIT_PASSWORD`), and patched code added since the original pull request.

You can test this locally by setting `BASHBREW_GIT_USERNAME` to your GitHub username and `BASHBREW_GIT_PASSWORD` to an access token, e.g., the output of the `gh auth token` command.  I recommend against specifying any password/token on the command line given how visible that is to other unprivileged processes or to attackers with access to one's shell history.

To test these changes in a GitHub Actions workflow:

1. Create a private GitHub repository containing a copy of [docker-library/hello-world](docker-library/hello-world).
2. [Register an app](https://docs.github.com/en/apps/creating-github-apps/registering-a-github-app/registering-a-github-app) in the organization, disable webhook functionality, and grant read-only [repository permissions for “Contents”](https://docs.github.com/en/rest/authentication/permissions-required-for-github-apps?apiVersion=2022-11-28#repository-permissions-for-contents).  After completing app registration, [generate a private key](https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/managing-private-keys-for-github-apps) and install the app in the organization, giving it access to the private repository created in step 1.
3. Create a private GitHub repository containing a copy of the file [**library/hello-world** from the Docker Official Images library](https://github.com/docker-library/official-images/blob/master/library/hello-world), changing `GitRepo` to that of the private repository created in step 1, and [**.github/workflows/ci.yaml** (attached)](https://github.com/user-attachments/files/27658972/ci.yaml), altering the bashbrew fork reference on line 42 as needed.  In the GitHub Actions configuration of the second repository, set the variable `PRIVATE_REPOSITORY_ACCESS_APP_ID` to the ID of the app created in step 2 and the secret `PRIVATE_REPOSITORY_ACCESS_KEY` to the app's private key.

When the workflow runs, you should see in the output something similar to the following:

```
+ bashbrew cat ./library/hello-world
Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon), Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
GitRepo: https://github.com/ResearchDataCom/hello-world.git
GitCommit: 0b0efba82b82ace81ab2fb42d25116f9488e6cb4
```

Note the private repository listed on the third line.

(The reference to the [de-vri-es/setup-git-credentials](https://github.com/de-vri-es/setup-git-credentials) action is unnecessary and only included to show the more customary Git credential store configuration.)